### PR TITLE
Enable ip_hash-based load balancing

### DIFF
--- a/templates/etc/nginx/sites-enabled/server.conf.erb
+++ b/templates/etc/nginx/sites-enabled/server.conf.erb
@@ -1,5 +1,6 @@
 <% if ENV['UPSTREAM_SERVERS'] %>
 upstream containers {
+  ip_hash;
   <% (ENV['UPSTREAM_SERVERS']).split(',').each do |server| %>
   server <%= server %>;
   <% end %>


### PR DESCRIPTION
@aaw: Does this look like a reasonable approach for getting decent-enough session affinity ("stickiness")? A good explanation is [here](http://nginx.org/en/docs/http/load_balancing.html#nginx_load_balancing_with_ip_hash) in the NGiNX docs. I don't think [any of the `sticky` methods](http://nginx.org/en/docs/http/ngx_http_upstream_module.html#sticky) are acceptable.