### PR TITLE
Base image off of alpine for smaller footprint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,41 +1,25 @@
-FROM quay.io/aptible/ubuntu:14.04
+FROM quay.io/aptible/alpine
 
-# Install NGiNX from source
-RUN apt-get update
-RUN apt-get -y install software-properties-common \
-      python-software-properties && \
-    add-apt-repository -y ppa:nginx/stable && apt-get update && \
-    apt-get -y install nginx && mkdir -p /etc/nginx/ssl
+# ruby necessary for ERB
+# curl necessary for integration tests
+RUN apk-install ruby=2.1.5-r1 curl
 
-# Install Ruby (necessary for ERB templating)
-RUN apt-get -y install ruby
+ADD install-nginx /tmp/
+RUN /tmp/install-nginx
 
-# Install Go (necessary for Heartbleed test)
-RUN apt-get -y install wget && cd /tmp && \
-    wget https://go.googlecode.com/files/go1.2.1.linux-amd64.tar.gz && \
-    tar -C /usr/local -xzf go1.2.1.linux-amd64.tar.gz
-
-# Install tcpserver for tests
-RUN apt-get -y install ucspi-tcp
-
-# Install cURL (necessary for integration tests)
-RUN apt-get -y install curl
-
-# Install HAProxy (necessary for Proxy Protocol integration tests)
-RUN add-apt-repository ppa:vbernat/haproxy-1.5
-RUN apt-get update && apt-get -y install haproxy
+# TODO: heartbleed test?
 
 ADD templates/etc /etc
 ADD templates/bin /usr/local/bin
 
 ADD test /tmp/test
-RUN bats /tmp/test
-
-# Uninstall Go
-RUN rm -rf /tmp/go1.2.1.linux-amd64.tar.gz /usr/local/go
-
-# Uninstall haproxy
-RUN apt-get -y remove haproxy
+# haproxy necessary for Proxy Protocol integration tests
+# haproxy 1.5 is not in the mainline alpine repository as of this writing (Feb 15, 2015).
+# cf. http://wiki.alpinelinux.org/wiki/Alpine_Linux_package_management#Add_a_Package
+RUN apk-install haproxy=1.5.10-r0 --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ \
+	&& bats /tmp/test \
+	&& rm -rf /tmp/nginx/* \
+	&& apk del haproxy
 
 VOLUME /etc/nginx/ssl
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ADD test /tmp/test
 # haproxy necessary for Proxy Protocol integration tests
 # haproxy 1.5 is not in the mainline alpine repository as of this writing (Feb 15, 2015).
 # cf. http://wiki.alpinelinux.org/wiki/Alpine_Linux_package_management#Add_a_Package
-RUN apk-install haproxy=1.5.10-r0 --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ \
+RUN apk-install haproxy=1.5.11-r0 --repository http://dl-4.alpinelinux.org/alpine/edge/main \
 	&& bats /tmp/test \
 	&& rm -rf /tmp/nginx/* \
 	&& apk del haproxy

--- a/install-nginx
+++ b/install-nginx
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+set -e
+
+mkdir /nginx && cd /nginx
+
+NGINX_VERSION=1.6.2
+wget http://nginx.org/download/nginx-$NGINX_VERSION.tar.gz
+tar zxf nginx-$NGINX_VERSION.tar.gz
+cd nginx-$NGINX_VERSION
+
+# This patch is necessary to compile against musl (Alpine's C standard library).
+# The patch has actually been merged into nginx, but later than 1.6.2.
+wget http://git.alpinelinux.org/cgit/aports/plain/main/nginx/musl-crypt-fix.patch
+patch -p1 -i musl-crypt-fix.patch
+
+# Cribbing from
+# http://git.alpinelinux.org/cgit/aports/tree/main/nginx/APKBUILD
+# but adding --with-http_realip_module to support "set_real_ip_from" directive
+# and removing some options which we may not need.
+apk-install build-base pcre-dev openssl-dev zlib-dev
+mkdir -p /tmp/nginx
+./configure \
+  --prefix=/usr \
+  --conf-path=/etc/nginx/nginx.conf \
+  --pid-path=/var/run/nginx.pid \
+  --lock-path=/var/run/nginx.lock \
+  --error-log-path=/var/log/nginx/error.log \
+  --http-log-path=/var/log/nginx/access.log \
+  --http-client-body-temp-path=/tmp/nginx/client-body \
+  --http-proxy-temp-path=/tmp/nginx/proxy \
+  --http-fastcgi-temp-path=/tmp/nginx/fastcgi \
+  --user=nginx \
+  --group=nginx \
+  --with-pcre-jit \
+  --with-http_ssl_module \
+  --with-http_gzip_static_module \
+  --with-http_realip_module
+make && make install
+apk del build-base openssl-dev pcre-dev zlib-dev && apk-install pcre
+cd / && rm -rf nginx
+
+# Create the user and group under which the nginx process will run.
+addgroup -S nginx 2>/dev/null || true
+adduser -G nginx -H -s /sbin/nologin -D nginx 2>/dev/null || true

--- a/templates/etc/nginx/nginx.conf
+++ b/templates/etc/nginx/nginx.conf
@@ -1,4 +1,4 @@
-user www-data;
+user nginx;
 worker_processes 4;
 pid /run/nginx.pid;
 

--- a/templates/etc/nginx/nginx.conf
+++ b/templates/etc/nginx/nginx.conf
@@ -26,8 +26,10 @@ http {
                        '"$request" $status $body_bytes_sent '
                        '"$http_referer" "$http_user_agent"';
 
-  access_log /dev/stdout;
-  error_log /dev/stdout;
+  # /dev/stdout is a symlink, pointing to /proc/self/fd/1.
+  # docker <0.12.0 has issues writing to it (on alpine?) for some reason.
+  access_log /proc/self/fd/1;
+  error_log /proc/self/fd/1;
 
   gzip on;
   gzip_disable "msie6";

--- a/templates/etc/nginx/sites-enabled/server.conf.erb
+++ b/templates/etc/nginx/sites-enabled/server.conf.erb
@@ -13,7 +13,7 @@ server {
   set_real_ip_from 0.0.0.0/0;
   real_ip_header proxy_protocol;
 
-  access_log /dev/stdout proxy_log;
+  access_log /proc/self/fd/1 proxy_log;
   <% else %>
   listen 80;
   <% end %>
@@ -51,7 +51,7 @@ server {
   set_real_ip_from 0.0.0.0/0;
   real_ip_header proxy_protocol;
 
-  access_log /dev/stdout proxy_log;
+  access_log /proc/self/fd/1 proxy_log;
   <% else %>
   listen 443;
   <% end %>

--- a/test/upstream-server
+++ b/test/upstream-server
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# inspired by
+# http://www.commandlinefu.com/commands/view/9164/one-command-line-web-server-on-port-80-using-nc-netcat
+while true; do nc -l -p 4000 127.0.0.1 < "$BATS_TEST_DIRNAME"/upstream-response.txt; done &


### PR DESCRIPTION
This is a rewrite of the Dockerfile in an effort to simplify and shrink the resulting image. Some notes:

* docker reports the resulting image to be 30.3 MB.
* vanilla nginx (i.e. the package found in Alpine's package repository) does not include the [real IP module](http://nginx.org/en/docs/http/ngx_http_realip_module.html) which the `set_real_ip_from` directive requires. As a result, it's necessary to build nginx from source. The build is performed in the script `/install-nginx`.
* the automated test for heartbleed was previously being skipped. For the time being, I've omitted the dependencies of that test (including a golang environment) to keep the image small.
* nginx now runs as the user `nginx`, rather than as the user `www-data`.