### PR TITLE
Fixing build and generating a 2048-bit group for EDH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,10 +16,10 @@ ADD test /tmp/test
 # haproxy necessary for Proxy Protocol integration tests
 # haproxy 1.5 is not in the mainline alpine repository as of this writing (Feb 15, 2015).
 # cf. http://wiki.alpinelinux.org/wiki/Alpine_Linux_package_management#Add_a_Package
-RUN apk-install haproxy=1.5.11-r0 --repository http://dl-4.alpinelinux.org/alpine/edge/main \
+RUN apk-install haproxy openssl-dev --repository http://dl-4.alpinelinux.org/alpine/edge/main \
 	&& bats /tmp/test \
 	&& rm -rf /tmp/nginx/* \
-	&& apk del haproxy
+	&& apk del haproxy openssl-dev
 
 VOLUME /etc/nginx/ssl
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,10 @@ RUN /tmp/install-nginx
 ADD templates/etc /etc
 ADD templates/bin /usr/local/bin
 
+# Generate a 2048-bit Diffie-Hellman group in line with recommendations
+# at https://weakdh.org/sysadmin.html.
+RUN openssl dhparam -out /etc/nginx/dhparams.pem 2048
+
 ADD test /tmp/test
 # haproxy necessary for Proxy Protocol integration tests
 # haproxy 1.5 is not in the mainline alpine repository as of this writing (Feb 15, 2015).

--- a/install-nginx
+++ b/install-nginx
@@ -11,7 +11,19 @@ cd nginx-$NGINX_VERSION
 
 # This patch is necessary to compile against musl (Alpine's C standard library).
 # The patch has actually been merged into nginx, but later than 1.6.2.
-wget http://git.alpinelinux.org/cgit/aports/plain/main/nginx/musl-crypt-fix.patch
+echo "--- bundle/src/os/unix/ngx_user.c.orig
++++ bundle/src/os/unix/ngx_user.c
+@@ -31,8 +31,10 @@
+     struct crypt_data   cd;
+
+     cd.initialized = 0;
++#ifdef __GLIBC__
+     /* work around the glibc bug */
+     cd.current_salt[0] = ~salt[0];
++#endif
+
+     value = crypt_r((char *) key, (char *) salt, &cd);
+" > musl-crypt-fix.patch
 patch -p1 -i musl-crypt-fix.patch
 
 # Cribbing from

--- a/templates/etc/nginx/nginx.conf
+++ b/templates/etc/nginx/nginx.conf
@@ -39,6 +39,7 @@ http {
   ssl_ciphers EECDH+ECDSA+AESGCM:EECDH+aRSA+AESGCM:EECDH+ECDSA+SHA384:EECDH+ECDSA+SHA256:EECDH+aRSA+SHA384:EECDH+aRSA+SHA256:EECDH+aRSA+RC4:EECDH:EDH+aRSA:RC4:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!SRP:!DSS:!CAMELLIA;
   ssl_protocols SSLv3 TLSv1 TLSv1.1 TLSv1.2;
   ssl_prefer_server_ciphers on;
+  ssl_dhparam /etc/nginx/dhparams.pem;
 
   include /etc/nginx/conf.d/*.conf;
   include /etc/nginx/sites-enabled/*.conf;

--- a/test/nginx.bats
+++ b/test/nginx.bats
@@ -132,3 +132,15 @@ teardown() {
   [ "$status" -ne "0" ]
   [[ "$output" =~ "inappropriate fallback" ]]
 }
+
+@test "It should use at least a 2048 EDH key" {
+  FORCE_SSL=true wait_for_nginx
+  run local_s_client -cipher "EDH"
+  [[ "$output" =~ "Server Temp Key: DH, 2048 bits" ]]
+}
+
+@test "It disables export ciphers" {
+  FORCE_SSL=true wait_for_nginx
+  run local_s_client -cipher "EXP"
+  [ "$status" -eq 1 ]
+}


### PR DESCRIPTION
Two commits here: the first is a build fix, since musl-crypt-fix.patch and haproxy-1.5.11-r0 moved. The second generates a 2048-bit group for EDH negotiation, which is in line with current recommendations from the Logjam folks. More background in both of the commit messages.

The idea for the bats tests for EDH and EXP ciphers comes from this OpenSSL post: https://openssl.org/blog/blog/2015/05/20/logjam-freak-upcoming-changes/

/cc @jbergknoff @fancyremarker 