### PR TITLE
Fix MAINTENANCE_PAGE_URL (closes #31)

### DIFF
--- a/templates/bin/nginx-wrapper
+++ b/templates/bin/nginx-wrapper
@@ -2,7 +2,7 @@
 
 # Prepare maintenance page
 if [ -n "${MAINTENANCE_PAGE_URL}" ]; then
-  wget $MAINTENANCE_PAGE_URL -O /usr/share/nginx/html/50x.html 2>/dev/null
+  curl -s "${MAINTENANCE_PAGE_URL}" > /usr/html/50x.html
 fi
 
 # Process ERB variables in server.conf

--- a/test/nginx.bats
+++ b/test/nginx.bats
@@ -75,7 +75,10 @@ teardown() {
 }
 
 @test "It should accept and configure a MAINTENANCE_PAGE_URL" {
-  skip
+  UPSTREAM_SERVERS=localhost:4000 \
+    MAINTENANCE_PAGE_URL=https://www.aptible.com/404.html wait_for_nginx
+  run curl localhost 2>/dev/null
+  [[ "$output" =~ "@aptiblestatus" ]]
 }
 
 @test "It should accept a list of UPSTREAM_SERVERS" {


### PR DESCRIPTION
This fixes one half of #31: that /50x.html pages (esp. as configured via MAINTENANCE_PAGE_URL) appear not to be served correctly on error.

The other half, that 404 pages were being returned for non-400 errors, appears not to be an issue after the Alpine switchover.
