### PR TITLE
Allow underscores in header names

### DIFF
--- a/templates/etc/nginx/nginx.conf
+++ b/templates/etc/nginx/nginx.conf
@@ -13,6 +13,7 @@ http {
   keepalive_timeout 65;
   types_hash_max_size 2048;
   client_max_body_size 0;
+  underscores_in_headers on;
 
   # http://stackoverflow.com/a/3710649
   proxy_buffers 8 16k;

--- a/test/nginx.bats
+++ b/test/nginx.bats
@@ -189,3 +189,13 @@ teardown() {
   run local_s_client -cipher "RC4-MD5" -ssl3
   [ "$status" -eq 0 ]
 }
+
+@test "It allows underscores in headers" {
+  rm /tmp/nc.log || true
+  nc -l -p 4000 127.0.0.1 > /tmp/nc.log &
+  UPSTREAM_SERVERS=localhost:4000 wait_for_nginx
+  curl --header "NoUnderscores: true" --header "SOME_UNDERSCORES: true" --max-time 1 http://localhost
+  run cat /tmp/nc.log
+  [[ "$output" =~ "NoUnderscores: true" ]]
+  [[ "$output" =~ "SOME_UNDERSCORES: true" ]]
+}


### PR DESCRIPTION
Headers with underscores in their names are perfectly valid, but NGiNX strips them by default to prevent ambiguities when mapping headers to CGI variables (http://wiki.nginx.org/Pitfalls#Missing_.28disappearing.29_HTTP_headers).

Headers with underscores are valid and many apps use them so we should keep them from being stripped. This patch turns the `underscores_in_headers` option on at the http level in the config.

Big thanks to @fancyremarker for identifying this as the underlying cause of some headers not getting through!