### PR TITLE
Add support for a DISABLE_WEAK_CIPHER_SUITES environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,30 @@ To force SSL, set the `FORCE_SSL` environment variable to `true`:
 
     docker run -e FORCE_SSL=true quay.io/aptible/nginx
 
+### Configuring supported protocols and cipher suites
+
+The default set of protocols and cipher suites exposed in our NGiNX
+configuration aims to balance security and compatibility with older clients.
+This default configuration mitigates the POODLE vulnerabilities by only allowing
+SSLv3 with the RC4 cipher. At the same time, it's accomodating enough to support
+even a default installation of IE6 on Windows XP or use as a custom origin
+behind AWS CloudFront over SSLv3/TLS1.
+
+There is, however, mounting evidence that RC4 is broken, which would mean that
+SSLv3 could not be used safely at all. To use a configuration that trades some
+compatibility for security set the `DISABLE_WEAK_CIPHER_SUITES` environment
+variable to `true`:
+
+    docker run -e DISABLE_WEAK_CIPHER_SUITES=true quay.io/aptible/nginx
+
+This flag turns off SSLv3 as well as the RC4 cipher. The configuration it
+generates earns an A+ on the Qualys SSL Labs
+[SSL Server Test](https://www.ssllabs.com/ssltest/) while providing
+compatibility with almost all clients that Qualys tests. The lone exception is
+IE 6 on Windows XP, which only fails because Qualys tests the default
+installation: if TLS 1.0 is enabled in IE 6, our configuration can be used to
+connect.
+
 ### Simulating trusted SSL connections
 
 If you're on OS X running boot2docker, you can configure your system to trust NGiNX's self-signed certificate by taking the following steps:

--- a/templates/bin/nginx-wrapper
+++ b/templates/bin/nginx-wrapper
@@ -5,9 +5,9 @@ if [ -n "${MAINTENANCE_PAGE_URL}" ]; then
   curl -s "${MAINTENANCE_PAGE_URL}" > /usr/html/50x.html
 fi
 
-# Process ERB variables in server.conf
-cd /etc/nginx/sites-enabled
-erb server.conf.erb > server.conf
+# Process ERB variables in nginx.conf and server.conf
+cd /etc/nginx && erb nginx.conf.erb > nginx.conf
+cd /etc/nginx/sites-enabled && erb server.conf.erb > server.conf
 
 if [ ! -f /etc/nginx/ssl/server.crt ]; then
   mkdir -p /etc/nginx/ssl

--- a/templates/etc/nginx/nginx.conf.erb
+++ b/templates/etc/nginx/nginx.conf.erb
@@ -35,12 +35,19 @@ http {
   gzip on;
   gzip_disable "msie6";
 
+<% if ENV['DISABLE_WEAK_CIPHER_SUITES'] %>
+  # Only TLS 1.0 and up, enable PFS for most clients but provide DES-CBC3-SHA
+  # for clients like IE 8 on Win XP or Java 6 that don't support PFS. IE 6 on
+  # Win XP can use DES-CBC3-SHA if TLS 1.0 is manually enabled on the client.
+  ssl_ciphers EECDH+ECDSA+AESGCM:EECDH+aRSA+AESGCM:EECDH+ECDSA+SHA384:EECDH+ECDSA+SHA256:EECDH+aRSA+SHA384:EECDH+aRSA+SHA256:EECDH:DES-CBC3-SHA:EDH+aRSA!aNULL:!eNULL:!LOW:!EXP:!PSK:!SRP:!DSS:!CAMELLIA:!RC4:!MD5;
+  ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+<% else %>
   # http://serverfault.com/a/637849
   # Enable PFS for most browsers, and provide SSLv3 while mitigating POODLE
   # Note: we're also disabling SSLv3+AES
   ssl_ciphers EECDH+ECDSA+AESGCM:EECDH+aRSA+AESGCM:EECDH+ECDSA+SHA384:EECDH+ECDSA+SHA256:EECDH+aRSA+SHA384:EECDH+aRSA+SHA256:EECDH+aRSA+RC4:EECDH:EDH+aRSA:RC4:!aNULL:!eNULL:!LOW:!3DES:!EXP:!PSK:!SRP:!DSS:!CAMELLIA:!SSLv3+AES;
-
   ssl_protocols SSLv3 TLSv1 TLSv1.1 TLSv1.2;
+<% end %>
   ssl_prefer_server_ciphers on;
   ssl_dhparam /etc/nginx/dhparams.pem;
 

--- a/test/nginx.bats
+++ b/test/nginx.bats
@@ -199,3 +199,15 @@ teardown() {
   [[ "$output" =~ "NoUnderscores: true" ]]
   [[ "$output" =~ "SOME_UNDERSCORES: true" ]]
 }
+
+@test "It does not allow SSLv3 if DISABLE_WEAK_CIPHER_SUITES is set" {
+  DISABLE_WEAK_CIPHER_SUITES=true wait_for_nginx
+  run local_s_client -ssl3
+  [ "$status" -eq 1 ]
+}
+
+@test "It does not allow RC4 if DISABLE_WEAK_CIPHER_SUITES is set" {
+  DISABLE_WEAK_CIPHER_SUITES=true wait_for_nginx
+  run local_s_client -cipher "RC4"
+  [ "$status" -eq 1 ]
+}


### PR DESCRIPTION
Our default NGiNX config provides a good balance between security and compatibility with older clients. This patch adds support for the environment variable DISABLE_WEAK_CIPHER_SUITES which, when set, disables SSLv3, the RC4 cipher, and MD5 for HMACs while adding support for TLS_RSA_WITH_3DES_EDE_CBC_SHA. The latter is used under TLS 1.0 to support IE 8 on Win XP and Java 6. The resulting configuration is also compatible with IE 6 under Win XP, but only if the client toggles a flag in their IE config to enable TLS 1.0.

The DISABLE_WEAK_CIPHER_SUITES config [earns an A+ on the Qualys SSL Server Test](https://www.ssllabs.com/ssltest/analyze.html?d=auth-aaw-sandbox.aptible-staging.com&latest) while supporting all clients they test except for the default installation of IE 6 on Win XP.

Ideally, we could continue to provide maximum compatibility in the default configuration without sacrificing practical vulnerability to any known attacks while guaranteeing that DISABLE_WEAK_CIPHER_SUITES will earn an A+ on the Qualys SSL Server Test but might sacrifice some compatibility in the process.

/cc @fancyremarker for review