### PR TITLE
Upgrading to 1.9.2

### DIFF
--- a/install-nginx
+++ b/install-nginx
@@ -4,27 +4,10 @@ set -e
 
 mkdir /nginx && cd /nginx
 
-NGINX_VERSION=1.6.2
+NGINX_VERSION=1.9.2
 wget http://nginx.org/download/nginx-$NGINX_VERSION.tar.gz
 tar zxf nginx-$NGINX_VERSION.tar.gz
 cd nginx-$NGINX_VERSION
-
-# This patch is necessary to compile against musl (Alpine's C standard library).
-# The patch has actually been merged into nginx, but later than 1.6.2.
-echo "--- bundle/src/os/unix/ngx_user.c.orig
-+++ bundle/src/os/unix/ngx_user.c
-@@ -31,8 +31,10 @@
-     struct crypt_data   cd;
-
-     cd.initialized = 0;
-+#ifdef __GLIBC__
-     /* work around the glibc bug */
-     cd.current_salt[0] = ~salt[0];
-+#endif
-
-     value = crypt_r((char *) key, (char *) salt, &cd);
-" > musl-crypt-fix.patch
-patch -p1 -i musl-crypt-fix.patch
 
 # Cribbing from
 # http://git.alpinelinux.org/cgit/aports/tree/main/nginx/APKBUILD

--- a/test/nginx.bats
+++ b/test/nginx.bats
@@ -46,9 +46,9 @@ teardown() {
   cp "$TMPDIR"/* /usr/html
 }
 
-@test "It should install NGiNX 1.6.2" {
+@test "It should install NGiNX 1.9.2" {
   run /usr/sbin/nginx -v
-  [[ "$output" =~ "1.6.2"  ]]
+  [[ "$output" =~ "1.9.2"  ]]
 }
 
 @test "It should pass an external Heartbleed test" {


### PR DESCRIPTION
We're playing around with nginx 1.9.2 since it has TCP load balancing. Not sure if you guys are interested, but if you were thinking of upgrading this could be a start.

We haven't look much at the change logs yet, but it all seemed to work fine with our local setup.

connects to #49 