### PR TITLE
Add support for ACME VHOSTs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,9 @@ ADD templates/bin /usr/local/bin
 RUN cd /usr/html \
  && erb 50x.html.erb > 50x.html
 
+RUN mkdir /html
+ADD templates/html/acme-pending.html.erb /html/
+
 ADD test /tmp/test
 RUN apk-install haproxy openssl-dev \
 	&& bats /tmp/test \

--- a/templates/bin/nginx-wrapper
+++ b/templates/bin/nginx-wrapper
@@ -35,4 +35,4 @@ if [ ! -f /etc/nginx/ssl/server.crt ]; then
   chmod og-rwx server.key
 fi
 
-/usr/sbin/nginx $@
+/usr/sbin/nginx "$@"

--- a/templates/bin/nginx-wrapper
+++ b/templates/bin/nginx-wrapper
@@ -5,6 +5,8 @@ if [ -n "${MAINTENANCE_PAGE_URL}" ]; then
   curl -s "${MAINTENANCE_PAGE_URL}" > /usr/html/50x.html
 fi
 
+cd /html && erb acme-pending.html.erb > acme-pending.html
+
 # Unless overridden, use a default configuration that enables PFS for most
 # browsers and provides SSLv3 while mitigating POODLE by avoiding CBC-mode
 # ciphers. Reference: http://serverfault.com/a/637849

--- a/templates/etc/nginx/sites-enabled/server.conf.erb
+++ b/templates/etc/nginx/sites-enabled/server.conf.erb
@@ -42,7 +42,7 @@ server {
     root /html;
     <% else %>
 
-    <% if (ENV['FORCE_SSL'] == 'true') || (ENV['ACME_READY'] == 'true') %>
+    <% if ENV['FORCE_SSL'] == 'true' %>
     return 301 https://$host$request_uri;
     <% end %>
 

--- a/templates/etc/nginx/sites-enabled/server.conf.erb
+++ b/templates/etc/nginx/sites-enabled/server.conf.erb
@@ -6,6 +6,12 @@ upstream containers {
 }
 <% end %>
 
+<% if ENV['ACME_SERVER'] %>
+upstream acme {
+  server <%= ENV['ACME_SERVER'] %>;
+}
+<% end %>
+
 server {
   <% if ENV['PROXY_PROTOCOL'] == 'true' %>
   listen 80 proxy_protocol;
@@ -24,7 +30,18 @@ server {
   location /50x.html {
   }
 
+  <% if ENV['ACME_SERVER'] %>
+  location /.well-known/acme-challenge {
+    proxy_pass http://acme;
+  }
+  <% end %>
+
   location / {
+    <% if ENV['ACME_PENDING'] %>
+    rewrite ^ /acme-pending.html break;
+    root /html;
+    <% else %>
+
     <% if ENV['FORCE_SSL'] == 'true' %>
     return 301 https://$host$request_uri;
     <% end %>
@@ -44,6 +61,7 @@ server {
     proxy_set_header Connection "upgrade";
     <% end %>
     break;
+    <% end %>
   }
 }
 
@@ -74,6 +92,11 @@ server {
   <% end %>
 
   location / {
+    <% if ENV['ACME_PENDING'] %>
+    rewrite ^ /acme-pending.html break;
+    root /html;
+    <% else %>
+
     proxy_set_header X-Forwarded-Proto https;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header Host $http_host;
@@ -89,5 +112,6 @@ server {
     proxy_set_header Connection "upgrade";
     <% end %>
     break;
+    <% end %>
   }
 }

--- a/templates/etc/nginx/sites-enabled/server.conf.erb
+++ b/templates/etc/nginx/sites-enabled/server.conf.erb
@@ -37,12 +37,12 @@ server {
   <% end %>
 
   location / {
-    <% if ENV['ACME_PENDING'] %>
+    <% if ENV['ACME_PENDING'] == 'true' %>
     rewrite ^ /acme-pending.html break;
     root /html;
     <% else %>
 
-    <% if (ENV['FORCE_SSL'] == 'true') || (ENV['ACME_DOMAIN'] && !ENV['ACME_PENDING']) %>
+    <% if (ENV['FORCE_SSL'] == 'true') || (ENV['ACME_READY'] == 'true') %>
     return 301 https://$host$request_uri;
     <% end %>
 

--- a/templates/etc/nginx/sites-enabled/server.conf.erb
+++ b/templates/etc/nginx/sites-enabled/server.conf.erb
@@ -42,7 +42,7 @@ server {
     root /html;
     <% else %>
 
-    <% if ENV['FORCE_SSL'] == 'true' %>
+    <% if (ENV['FORCE_SSL'] == 'true') || (ENV['ACME_DOMAIN'] && !ENV['ACME_PENDING']) %>
     return 301 https://$host$request_uri;
     <% end %>
 

--- a/templates/html/acme-pending.html.erb
+++ b/templates/html/acme-pending.html.erb
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Endpoint Setup | Aptible</title>
+  <script type="text/javascript" src="//use.typekit.net/hen3udh.js"></script>
+  <script type="text/javascript">try{Typekit.load();}catch(e){}</script>
+  <style type="text/css">
+    .wf-loading .blog-title, .wf-loading .post-title {
+        /* Prevents FOUT while fonts are loading */
+        visibility: hidden;
+      }
+  </style>
+  <style>
+    body {
+      background-color: white;
+      color: black;
+      text-align: center;
+      font-family: "proxima-nova", arial, "open-sans", sans-serif;
+    }
+
+    div.logo {
+      height: 300px;
+      width: 300px;
+      margin: 0 auto 0 auto;
+      background-image: url('https://s.gravatar.com/avatar/3fdb74838e87cd36c68ce2135900f01a?s=300');
+    }
+
+    div.dialog {
+      width: 500px;
+      margin: 75px auto 0 auto;
+      padding: 7px 4em 0 4em;
+    }
+
+    h1 {
+      color: #006699;
+      line-height: 1em;
+    }
+
+    body > p {
+      width: 500px;
+      margin: 0 auto 1em;
+      padding: 1em 0;
+      background-color: #003366;
+      border: 1px solid #CCC;
+      border-right-color: #999;
+      border-bottom-color: #999;
+      border-bottom-left-radius: 4px;
+      border-bottom-right-radius: 4px;
+      border-top-color: #DADADA;
+      color: #666;
+      box-shadow:0 3px 8px rgba(50, 50, 50, 0.17);
+    }
+
+    ul {
+      list-style-type: none;
+      display: inline-block;
+      padding-left: 0px;
+    }
+
+    ul > li {
+      display: inline;
+      padding-left: 10px;
+      padding-right: 10px;
+    }
+
+    code {
+      font-weight: bold;
+    }
+
+    a {
+      color: #006699;
+    }
+    a:link {
+      text-decoration: none;
+    }
+    a:visited {
+      text-decoration: none;
+    }
+    a:hover {
+      text-decoration: underline;
+    }
+    a:active {
+      text-decoration: none;
+    }
+
+    .circle-icon {
+      display: block;
+      margin: 0 auto;
+      height: 40px;
+      width: 40px;
+      background-image: url('https://www.aptible.com/assets/images/tiny-grayscale-logo.png');
+    }
+
+    .circle-icon:hover {
+      background-image: url('https://www.aptible.com/assets/images/tiny-color-logo.png');
+    }
+
+  </style>
+</head>
+
+<body>
+  <div class="dialog">
+    <div class="logo"></div>
+    <h1>Almost done!</h1>
+    <p>
+      To finish setting up <code><%= ENV['ACME_DOMAIN'] %></code> with Aptible,
+      create a CNAME to this domain from <code><%= ENV['ACME_DOMAIN'] %></code>
+      via your DNS provider.
+    </p>
+    <p>
+      Then, go back to the Aptible Dashboard and click "I created the CNAME".
+    </p>
+  </div>
+  <ul>
+    <li><a href="https://twitter.com/aptible">@aptible</a></li>
+    <li><a href="http://help.aptible.com">Contact Support</a></li>
+  </ul>
+  <a class="circle-icon" href="https://www.aptible.com"></a>
+</body>
+</html>

--- a/test/acme.txt
+++ b/test/acme.txt
@@ -1,0 +1,5 @@
+HTTP/1.1 200 OK
+Content-Type: text/plain
+Content-Length: 14
+
+ACME Response

--- a/test/nginx.bats
+++ b/test/nginx.bats
@@ -361,12 +361,12 @@ NGINX_VERSION=1.9.2
   [[ "$output" =~ 'finish setting up' ]]
 }
 
-@test "When ACME is ready, it redirects to SSL, but does not set HSTS headers" {
+@test "When ACME is ready, it doesn't redirect to SSL without FORCE_SSL" {
   ACME_READY="true" wait_for_nginx
 
-  run curl -I localhost 2>/dev/null
-  [[ "$output" =~ "HTTP/1.1 301 Moved Permanently" ]]
-  [[ "$output" =~ "Location: https://localhost" ]]
+  run curl -sI localhost 2>/dev/null
+  [[ "$output" =~ "HTTP/1.1 200 OK" ]]
+  [[ ! "$output" =~ "HTTP/1.1 301 Moved Permanently" ]]
 
   run curl -Ik https://localhost 2>/dev/null
   [[ ! "$output" =~ "Strict-Transport-Security:" ]]

--- a/test/nginx.bats
+++ b/test/nginx.bats
@@ -360,3 +360,25 @@ NGINX_VERSION=1.9.2
   [[ "$output" =~ 'some.domain.com' ]]
   [[ "$output" =~ 'finish setting up' ]]
 }
+
+@test "When ACME is enabled, it redirects to SSL, but does not set HSTS headers" {
+  ACME_DOMAIN="some.domain.com" wait_for_nginx
+
+  run curl -I localhost 2>/dev/null
+  [[ "$output" =~ "HTTP/1.1 301 Moved Permanently" ]]
+  [[ "$output" =~ "Location: https://localhost" ]]
+
+  run curl -Ik https://localhost 2>/dev/null
+  [[ ! "$output" =~ "Strict-Transport-Security:" ]]
+}
+
+@test "When ACME is enabled with FORCE_SSL, it redirects to SSL and sets HSTS headers" {
+  ACME_DOMAIN="some.domain.com" FORCE_SSL="true" wait_for_nginx
+
+  run curl -I localhost 2>/dev/null
+  [[ "$output" =~ "HTTP/1.1 301 Moved Permanently" ]]
+  [[ "$output" =~ "Location: https://localhost" ]]
+
+  run curl -Ik https://localhost 2>/dev/null
+  [[ "$output" =~ "Strict-Transport-Security:" ]]
+}

--- a/test/nginx.bats
+++ b/test/nginx.bats
@@ -352,7 +352,7 @@ NGINX_VERSION=1.9.2
 }
 
 @test "It serves a static information page if ACME_PENDING is set" {
-  ACME_PENDING=true ACME_DOMAIN="some.domain.com" wait_for_nginx
+  ACME_PENDING="true" ACME_DOMAIN="some.domain.com" wait_for_nginx
   run curl "http://localhost/.well-known/acme-challenge/123"
   [[ "$output" =~ 'some.domain.com' ]]
   [[ "$output" =~ 'finish setting up' ]]
@@ -361,8 +361,8 @@ NGINX_VERSION=1.9.2
   [[ "$output" =~ 'finish setting up' ]]
 }
 
-@test "When ACME is enabled, it redirects to SSL, but does not set HSTS headers" {
-  ACME_DOMAIN="some.domain.com" wait_for_nginx
+@test "When ACME is ready, it redirects to SSL, but does not set HSTS headers" {
+  ACME_READY="true" wait_for_nginx
 
   run curl -I localhost 2>/dev/null
   [[ "$output" =~ "HTTP/1.1 301 Moved Permanently" ]]
@@ -373,7 +373,7 @@ NGINX_VERSION=1.9.2
 }
 
 @test "When ACME is enabled with FORCE_SSL, it redirects to SSL and sets HSTS headers" {
-  ACME_DOMAIN="some.domain.com" FORCE_SSL="true" wait_for_nginx
+  ACME_READY="true" FORCE_SSL="true" wait_for_nginx
 
   run curl -I localhost 2>/dev/null
   [[ "$output" =~ "HTTP/1.1 301 Moved Permanently" ]]


### PR DESCRIPTION
This complements https://github.com/aptible/sweetness/pull/606:

cc @fancyremarker @blakepettersson 

This adds support for ACME in our Nginx proxy. This effectively does two
things:

- When `ACME_SERVER` is set, the Nginx proxy will redirect requests to
  `/.well-known/acme-challenge` to the `ACME_SERVER`. This allows
  running `http-01` ACME assertions via the endpoint, even when serving
  live app traffic.
- When `ACME_PENDING` is set, the Nginx proxy will no longer serve the
  app it's proxying to, but will instead serve a static webpage
  instructing users to finish their ACME setup. This is here to remind
  users that navigate to their app domain before completing ACME setup
  that they're not done yet.