### PR TITLE
Make simulate-upstream more versatile

### DIFF
--- a/test/upstream-server
+++ b/test/upstream-server
@@ -1,5 +1,13 @@
 #!/bin/sh
 
+PORT="${UPSTREAM_PORT:-"4000"}"
+RESPONSE="$BATS_TEST_DIRNAME"/"${UPSTREAM_RESPONSE:-"upstream-response.txt"}"
+OUTPUT="${UPSTREAM_OUT:-"/tmp/$$.log"}"
+
 # inspired by
 # http://www.commandlinefu.com/commands/view/9164/one-command-line-web-server-on-port-80-using-nc-netcat
-while true; do nc -l -p 4000 127.0.0.1 < "$BATS_TEST_DIRNAME"/upstream-response.txt; done &
+echo > "$OUTPUT"
+while true; do
+  nc -l -p "$PORT" 127.0.0.1 < "$RESPONSE" >> "$OUTPUT"
+done
+rm -f "$OUTPUT"


### PR DESCRIPTION
This doesn't affect any of the tests we currently run, but is convenient
both for the ACME branch and X-Forwarded-Proto specs, so I'm extracting
it into a separate commit.

cc @fancyremarker 