### PR TITLE
Force x forwarded proto

### DIFF
--- a/templates/etc/nginx/sites-enabled/server.conf.erb
+++ b/templates/etc/nginx/sites-enabled/server.conf.erb
@@ -29,6 +29,7 @@ server {
     return 301 https://$host$request_uri;
     <% end %>
 
+    proxy_set_header X-Forwarded-Proto http;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header Host $http_host;
     proxy_set_header X-Request-Start "t=${msec}";

--- a/test/nginx.bats
+++ b/test/nginx.bats
@@ -258,6 +258,26 @@ teardown() {
   [[ "$output" =~ "X-Request-Start: t=" ]]
 }
 
+@test "It forces X-Forwarded-Proto = http for HTTP requests" {
+  LOG="nc.log"
+  UPSTREAM_OUT="$LOG" simulate_upstream
+  UPSTREAM_SERVERS=localhost:4000 wait_for_nginx
+  curl -s -H 'X-Forwarded-Proto: https' http://localhost
+
+  grep 'X-Forwarded-Proto: http' "$LOG"
+  run grep 'X-Forwarded-Proto: https' "$LOG"
+  [[ "$status" -eq 1 ]]
+}
+
+@test "It forces X-Forwarded-Proto = https for HTTPS requests" {
+  LOG="nc.log"
+  UPSTREAM_OUT="$LOG" simulate_upstream
+  UPSTREAM_SERVERS=localhost:4000 wait_for_nginx
+  curl -sk -H 'X-Forwarded-Proto: http' https://localhost
+
+  grep 'X-Forwarded-Proto: https' "$LOG"
+}
+
 @test "It supports GZIP compression of responses" {
   simulate_upstream
   UPSTREAM_SERVERS=localhost:4000 wait_for_nginx


### PR DESCRIPTION
This ensures clients can't spoof the X-Forwarded-Proto header.

Fixes https://github.com/aptible/docker-nginx/issues/60