### PR TITLE
Do not include Nginx version in Server header

### DIFF
--- a/templates/etc/nginx/nginx.conf.erb
+++ b/templates/etc/nginx/nginx.conf.erb
@@ -45,6 +45,8 @@ http {
   ssl_prefer_server_ciphers on;
   ssl_dhparam /etc/nginx/dhparams.pem;
 
+  server_tokens off;
+
   include /etc/nginx/conf.d/*.conf;
   include /etc/nginx/sites-enabled/*.conf;
 }

--- a/test/nginx.bats
+++ b/test/nginx.bats
@@ -46,9 +46,18 @@ teardown() {
   cp "$TMPDIR"/* /usr/html
 }
 
-@test "It should install NGiNX 1.9.2" {
+NGINX_VERSION=1.9.2
+
+@test "It should install NGiNX $NGINX_VERSION" {
   run /usr/sbin/nginx -v
-  [[ "$output" =~ "1.9.2"  ]]
+  [[ "$output" =~ "$NGINX_VERSION"  ]]
+}
+
+@test "It does not include the Nginx version" {
+  wait_for_nginx
+  run curl -v http://localhost
+  echo "$output"
+  [[ ! "$output" =~ "$NGINX_VERSION" ]]
 }
 
 @test "It should pass an external Heartbleed test" {


### PR DESCRIPTION
This won't really change anything security-wise, but it'll silence
scanners that encourage security by obscurity..!

cc @fancyremarker 