### PR TITLE
Acme OCSP stapling

### DIFF
--- a/install-nginx
+++ b/install-nginx
@@ -1,13 +1,19 @@
 #!/bin/sh
-
-set -e
+set -o nounset
+set -o errexit
+set -o pipefail
 
 mkdir /nginx && cd /nginx
 
-NGINX_VERSION=1.9.2
-wget http://nginx.org/download/nginx-$NGINX_VERSION.tar.gz
-tar zxf nginx-$NGINX_VERSION.tar.gz
-cd nginx-$NGINX_VERSION
+NGINX_VERSION='1.10.1'
+NGINX_SHASUM='9c5d4e06d309bbe2efa41f09dd53912e3c3d3a75'
+
+NGINX_ARCHIVE="nginx-$NGINX_VERSION.tar.gz"
+
+wget "http://nginx.org/download/${NGINX_ARCHIVE}"
+echo "${NGINX_SHASUM}  ${NGINX_ARCHIVE}" | sha1sum -c -
+tar zxf "$NGINX_ARCHIVE"
+cd "nginx-$NGINX_VERSION"
 
 # Cribbing from
 # http://git.alpinelinux.org/cgit/aports/tree/main/nginx/APKBUILD

--- a/templates/etc/nginx/sites-enabled/server.conf.erb
+++ b/templates/etc/nginx/sites-enabled/server.conf.erb
@@ -81,6 +81,11 @@ server {
   ssl_certificate /etc/nginx/ssl/server.crt;
   ssl_certificate_key /etc/nginx/ssl/server.key;
 
+  <% if ENV['ACME_READY'] == 'true' %>
+  ssl_stapling on;
+  resolver 8.8.8.8 8.8.4.4;
+  <% end %>
+
   keepalive_timeout 5;
 
   error_page 502 503 504 /50x.html;

--- a/test/nginx.bats
+++ b/test/nginx.bats
@@ -46,7 +46,7 @@ teardown() {
   cp "$TMPDIR"/* /usr/html
 }
 
-NGINX_VERSION=1.9.2
+NGINX_VERSION=1.10.1
 
 @test "It should install NGiNX $NGINX_VERSION" {
   run /usr/sbin/nginx -v

--- a/test/nginx.bats
+++ b/test/nginx.bats
@@ -382,3 +382,8 @@ NGINX_VERSION=1.10.1
   run curl -Ik https://localhost 2>/dev/null
   [[ "$output" =~ "Strict-Transport-Security:" ]]
 }
+
+@test "When ACME_READY is set, it enables OCSP stapling" {
+  ACME_READY="true" FORCE_SSL="true" wait_for_nginx
+  openssl s_client -connect acme-123.jesuispasdaccord.fr:443 -tlsextdebug  -status </dev/null | grep 'OCSP Response Status'
+}


### PR DESCRIPTION
- Upgrade to Nginx 1.10.1

We're going to want to use the resolver directive (for OCSP support),
which was insecure in odler versions of Nginx. This upgrades us to Nginx
1.10.1 (the latest stable version of Nginx).

- OCSP stapling for ACME servers 

Let's Encrypt recommends enabling OCSP stapling in their integration
guide (https://letsencrypt.org/docs/integration-guide/), and we do so
here. The main benefit of OCSP is to avoid an OCSP revokation check
being made when a browser attempts to connect to a site using one of our
ACME certificates.

In the longer term, we might want to:

- Expose this for non-ACME hosts.
- Enable `ssl_stapling_verify`.

The latter in particular should be done with care. While adding an OCSP
staple to our responses (even if it's merely a fail) shouldn't possibly
do harm, it's probably best to leave it up to the client browser to
decide whether the OCSP response is a fail or a pass.


--

cc @fancyremarker 