### PR TITLE
Http health checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM quay.io/aptible/alpine
 # curl necessary for integration tests
 RUN apk-install ruby curl
 
+# Install Nginx itself
 ADD install-nginx /tmp/
 RUN /tmp/install-nginx
 
@@ -24,12 +25,12 @@ ADD templates/html/acme-pending.html.erb /html/
 
 ADD test /tmp/test
 RUN apk-install haproxy openssl-dev \
-	&& bats /tmp/test \
-	&& rm -rf /tmp/nginx/* \
-	&& apk del haproxy openssl-dev
+ && bats /tmp/test \
+ && rm -rf /tmp/nginx/* \
+ && apk del haproxy openssl-dev
 
 VOLUME /etc/nginx/ssl
 
-EXPOSE 80 443
+EXPOSE 80 443 9000
 
 CMD ["/usr/local/bin/nginx-wrapper"]

--- a/install-nginx
+++ b/install-nginx
@@ -7,20 +7,51 @@ mkdir /nginx && cd /nginx
 
 NGINX_VERSION='1.10.1'
 NGINX_SHASUM='9c5d4e06d309bbe2efa41f09dd53912e3c3d3a75'
+NGINX_RESOURCE="nginx-${NGINX_VERSION}"
+NGINX_ARCHIVE="${NGINX_RESOURCE}.tar.gz"
 
-NGINX_ARCHIVE="nginx-$NGINX_VERSION.tar.gz"
+NGX_DEVEL_KIT_VERSION="0.3.0"
+NGX_DEVEL_KIT_SHASUM="b556d068db23037be30436af559795f45dd93c67"
+NGX_DEVEL_KIT_RESOURCE="ngx_devel_kit-${NGX_DEVEL_KIT_VERSION}"
+NGX_DEVEL_KIT_ARCHIVE="${NGX_DEVEL_KIT_RESOURCE}.tar.gz"
 
-wget "http://nginx.org/download/${NGINX_ARCHIVE}"
+NGX_LUA_VERSION="0.10.6"
+NGX_LUA_SHASUM="8f32f89abe60944f96655bb7646a30748ac41463"
+NGX_LUA_RESOURCE="lua-nginx-module-${NGX_LUA_VERSION}"
+NGX_LUA_ARCHIVE="${NGX_LUA_RESOURCE}.tar.gz"
+
+BUILD_DIR="$(mktemp -d)"
+
+cd "$BUILD_DIR"
+
+curl -fsSL "http://nginx.org/download/${NGINX_ARCHIVE}" -o "$NGINX_ARCHIVE"
 echo "${NGINX_SHASUM}  ${NGINX_ARCHIVE}" | sha1sum -c -
 tar zxf "$NGINX_ARCHIVE"
-cd "nginx-$NGINX_VERSION"
+
+curl -fsSL "https://github.com/simpl/ngx_devel_kit/archive/v${NGX_DEVEL_KIT_VERSION}.tar.gz" -o "$NGX_DEVEL_KIT_ARCHIVE"
+echo "${NGX_DEVEL_KIT_SHASUM}  ${NGX_DEVEL_KIT_ARCHIVE}" | sha1sum -c -
+tar zxf "$NGX_DEVEL_KIT_ARCHIVE"
+
+curl -fsSL "https://github.com/openresty/lua-nginx-module/archive/v${NGX_LUA_VERSION}.tar.gz" -o "$NGX_LUA_ARCHIVE"
+echo "${NGX_LUA_SHASUM}  ${NGX_LUA_ARCHIVE}" | sha1sum -c -
+tar zxf "$NGX_LUA_ARCHIVE"
+
+echo "Downloaded:"
+ls -l
+
+cd "$NGINX_RESOURCE"
 
 # Cribbing from
 # http://git.alpinelinux.org/cgit/aports/tree/main/nginx/APKBUILD
 # but adding --with-http_realip_module to support "set_real_ip_from" directive
 # and removing some options which we may not need.
-apk-install build-base pcre-dev openssl-dev zlib-dev
+apk-install build-base pcre pcre-dev openssl openssl-dev zlib zlib-dev luajit luajit-dev
+
+export LUAJIT_LIB=/usr/lib
+export LUAJIT_INC=/usr/include/luajit-2.0
+
 mkdir -p /tmp/nginx
+
 ./configure \
   --prefix=/usr \
   --conf-path=/etc/nginx/nginx.conf \
@@ -36,11 +67,17 @@ mkdir -p /tmp/nginx
   --with-pcre-jit \
   --with-http_ssl_module \
   --with-http_gzip_static_module \
-  --with-http_realip_module
-make && make install
-apk del build-base openssl-dev pcre-dev zlib-dev && apk-install pcre
-cd / && rm -rf nginx
+  --with-http_realip_module \
+  --add-module="../${NGX_DEVEL_KIT_RESOURCE}" \
+  --add-module="../${NGX_LUA_RESOURCE}"
+
+make
+make install
+apk del build-base openssl-dev pcre-dev zlib-dev
 
 # Create the user and group under which the nginx process will run.
 addgroup -S nginx 2>/dev/null || true
 adduser -G nginx -H -s /sbin/nologin -D nginx 2>/dev/null || true
+
+# Finally, clean everything up
+rm -rf "$BUILD_DIR"

--- a/templates/bin/nginx-wrapper
+++ b/templates/bin/nginx-wrapper
@@ -25,8 +25,9 @@ fi
 [ -n "$SSL_PROTOCOLS_OVERRIDE" ] && SSL_PROTOCOLS="${SSL_PROTOCOLS_OVERRIDE//;}"
 export SSL_CIPHERS SSL_PROTOCOLS
 
-# Process ERB variables in nginx.conf and server.conf
+# Process ERB variables in Nginx configuration templates
 cd /etc/nginx && erb nginx.conf.erb > nginx.conf
+cd /etc/nginx/partial && erb health.conf.erb > health.conf
 cd /etc/nginx/sites-enabled && erb server.conf.erb > server.conf
 
 if [ ! -f /etc/nginx/ssl/server.crt ]; then

--- a/templates/etc/nginx/partial/health.conf.erb
+++ b/templates/etc/nginx/partial/health.conf.erb
@@ -1,0 +1,33 @@
+location = @healthcheck {
+  internal;
+
+  proxy_method GET;
+  proxy_pass_request_headers off;
+  proxy_pass_request_body off;
+  proxy_set_header User-Agent "Aptible Health Check";
+
+  rewrite ^ /healthcheck break;
+
+  <% if ENV['UPSTREAM_SERVERS'] %>
+    proxy_pass http://containers;
+  <% else %>
+    return 502;
+  <% end %>
+}
+
+location = /.aptible/alb-healthcheck {
+  default_type 'text/plain';
+
+  <% if ENV['FORCE_HEALTHCHECK_SUCCESS'] == 'true' %>
+    return 200 "";
+  <% else %>
+    content_by_lua_block {
+    local r = ngx.location.capture("@healthcheck");
+    if r.status == 502 then
+    ngx.status = 502;
+    else
+    ngx.status = 200;
+    end
+    }
+  <% end %>
+}

--- a/templates/etc/nginx/sites-enabled/server.conf.erb
+++ b/templates/etc/nginx/sites-enabled/server.conf.erb
@@ -120,3 +120,41 @@ server {
     <% end %>
   }
 }
+
+<% if ENV['UPSTREAM_SERVERS'] %>
+server {
+  listen 9000;
+
+  access_log /proc/self/fd/1 proxy_log;
+
+  location = / {
+    default_type 'text/plain';
+
+    content_by_lua_block {
+      local r = ngx.location.capture("/healthcheck");
+      if r.status == 502 then
+        ngx.status = 502;
+      else
+        ngx.status = 200;
+      end
+    }
+  }
+
+  location = /healthcheck {
+    internal;
+
+    proxy_method GET;
+    proxy_pass_request_headers off;
+    proxy_pass_request_body off;
+    proxy_set_header User-Agent "Aptible Health Check";
+
+    proxy_pass http://containers;
+  }
+
+  location / {
+    # Send all requests to /
+    rewrite ^.*$ / last;
+  }
+
+}
+<% end %>

--- a/templates/etc/nginx/sites-enabled/server.conf.erb
+++ b/templates/etc/nginx/sites-enabled/server.conf.erb
@@ -36,6 +36,8 @@ server {
   }
   <% end %>
 
+  include /etc/nginx/partial/health.conf;
+
   location / {
     <% if ENV['ACME_PENDING'] == 'true' %>
     rewrite ^ /acme-pending.html break;
@@ -95,6 +97,8 @@ server {
   <% if ENV['FORCE_SSL'] == 'true' %>
   add_header Strict-Transport-Security max-age=<%= ENV['HSTS_MAX_AGE'] || 31536000 %>;
   <% end %>
+
+  include /etc/nginx/partial/health.conf;
 
   location / {
     <% if ENV['ACME_PENDING'] %>

--- a/templates/etc/nginx/sites-enabled/server.conf.erb
+++ b/templates/etc/nginx/sites-enabled/server.conf.erb
@@ -130,6 +130,9 @@ server {
   location = / {
     default_type 'text/plain';
 
+    <% if ENV['FORCE_HEALTHCHECK_SUCCESS'] == 'true' %>
+    return 200 "";
+    <% else %>
     content_by_lua_block {
       local r = ngx.location.capture("/healthcheck");
       if r.status == 502 then
@@ -138,6 +141,7 @@ server {
         ngx.status = 200;
       end
     }
+    <% end %>
   }
 
   location = /healthcheck {

--- a/test/nginx.bats
+++ b/test/nginx.bats
@@ -382,8 +382,3 @@ NGINX_VERSION=1.10.1
   run curl -Ik https://localhost 2>/dev/null
   [[ "$output" =~ "Strict-Transport-Security:" ]]
 }
-
-@test "When ACME_READY is set, it enables OCSP stapling" {
-  ACME_READY="true" FORCE_SSL="true" wait_for_nginx
-  openssl s_client -connect acme-123.jesuispasdaccord.fr:443 -tlsextdebug  -status </dev/null | grep 'OCSP Response Status'
-}

--- a/test/upstream-response-500.txt
+++ b/test/upstream-response-500.txt
@@ -1,0 +1,5 @@
+HTTP/1.1 500 INTERNAL SERVER ERROR
+Content-Type: application/json
+Content-Length: 30
+
+{ "message": "Oops, World!" }


### PR DESCRIPTION
This exposes a third port on the instance (9000), which can be used for
health checks. This will accept regular HTTP requests and forward them
to a `/healthcheck` endpoint in the underlying app.

If the app responds (regardless of the status), the health check is
considered successful and we return a 200 (which an ELB will interpret
as a pass), and otherwise we return a 502 (which it will interpret as
failure).

All request and response components are discarded (the server never sees
the client's intput, and the client never sees the server response) so
that we don't send anything over the wire unencrypted.

Unfortunately, doing either of those things (returning a blanket 200 and
removing response content) can't be done with "regular" Nginx, so we're
pulling in the OpenResty Lua module to help with that.

--

In the longer term, we might want to start letting customers declare health checks that check connectivity beyond the basic "does this respond over HTTP?" check, but this is a fist step towards bringing the health checks we do on ELBs and Sweetness in line!

(as a reminder: ELBs can't poll our Nginx proxies because we're using the PROXY protocol, which makes the health checks a lot less useful than they'd otherwise be)

cc @fancyremarker @blakepettersson 