### PR TITLE
Enforce HSTS on every response

### DIFF
--- a/templates/etc/nginx/sites-enabled/server.conf.erb
+++ b/templates/etc/nginx/sites-enabled/server.conf.erb
@@ -95,7 +95,7 @@ server {
   }
 
   <% if ENV['FORCE_SSL'] == 'true' %>
-  add_header Strict-Transport-Security max-age=<%= ENV['HSTS_MAX_AGE'] || 31536000 %>;
+  add_header Strict-Transport-Security "max-age=<%= ENV['HSTS_MAX_AGE'] || 31536000 %>" always;
   <% end %>
 
   include /etc/nginx/partial/health.conf;


### PR DESCRIPTION
We received a low-level alert from one our security scanners that the HSTS header was missing in some marginal cases (like on an error response). This PR should in theory make sure it is always returned.