### PR TITLE
Log SSL protocol and cipher, host, request time

### DIFF
--- a/templates/etc/nginx/nginx.conf.erb
+++ b/templates/etc/nginx/nginx.conf.erb
@@ -25,9 +25,14 @@ http {
   include /etc/nginx/mime.types;
   default_type application/octet-stream;
 
-  # Mirror default "combined" log format, but with Proxy Protocol address
-  log_format proxy_log '$proxy_protocol_addr $host $remote_user [$time_local] '
-                       '"$request" $status $body_bytes_sent '
+  log_format proxy_log '$proxy_protocol_addr $ssl_protocol/$ssl_cipher '
+                       '$host $remote_user [$time_local] '
+                       '"$request" $status $body_bytes_sent $request_time '
+                       '"$http_referer" "$http_user_agent"';
+
+  log_format http_log  '$remote_addr $ssl_protocol/$ssl_cipher '
+                       '$host $remote_user [$time_local] '
+                       '"$request" $status $body_bytes_sent $request_time '
                        '"$http_referer" "$http_user_agent"';
 
   # /dev/stdout is a symlink, pointing to /proc/self/fd/1.

--- a/templates/etc/nginx/sites-enabled/server.conf.erb
+++ b/templates/etc/nginx/sites-enabled/server.conf.erb
@@ -22,6 +22,8 @@ server {
   access_log /proc/self/fd/1 proxy_log;
   <% else %>
   listen 80;
+
+  access_log /proc/self/fd/1 http_log;
   <% end %>
 
   keepalive_timeout 5;
@@ -77,6 +79,8 @@ server {
   access_log /proc/self/fd/1 proxy_log;
   <% else %>
   listen 443;
+
+  access_log /proc/self/fd/1 http_log;
   <% end %>
 
   ssl on;
@@ -129,7 +133,7 @@ server {
 server {
   listen 9000;
 
-  access_log /proc/self/fd/1 proxy_log;
+  access_log /proc/self/fd/1 http_log;
 
   location = / {
     default_type 'text/plain';


### PR DESCRIPTION
This unifies our logging format for proxy protocol and HTTP, and adds
the SSL protocol and cipher, as well as the request time. SSL parameters
will be helpful to help customers deprecate support for SSLv3 (and
ideally migrate to ALBs in the process), and the latter is something
we've often wanted to use in debugging.

This also adds test that actually check these fields are logged.

Note that the new log format isn't really compliant with the combined
log format anymore... but that probably doesn't matter.

---

cc @fancyremarker @blakepettersson 