### PR TITLE
Allow setting a custom KEEPALIVE_TIMEOUT

### DIFF
--- a/templates/bin/nginx-wrapper
+++ b/templates/bin/nginx-wrapper
@@ -25,6 +25,11 @@ fi
 [ -n "$SSL_PROTOCOLS_OVERRIDE" ] && SSL_PROTOCOLS="${SSL_PROTOCOLS_OVERRIDE//;}"
 export SSL_CIPHERS SSL_PROTOCOLS
 
+if [[ -n "$KEEPALIVE_TIMEOUT" ]] && [[ ! "$KEEPALIVE_TIMEOUT" =~ ^[0-9]+$ ]]; then
+  echo "KEEPALIVE_TIMEOUT=${KEEPALIVE_TIMEOUT} is not acceptable!" >&2
+  unset KEEPALIVE_TIMEOUT
+fi
+
 # Process ERB variables in Nginx configuration templates
 cd /etc/nginx && erb nginx.conf.erb > nginx.conf
 cd /etc/nginx/partial && erb health.conf.erb > health.conf

--- a/templates/etc/nginx/nginx.conf.erb
+++ b/templates/etc/nginx/nginx.conf.erb
@@ -10,7 +10,7 @@ http {
   sendfile on;
   tcp_nopush on;
   tcp_nodelay on;
-  keepalive_timeout 65;
+  keepalive_timeout <%= ENV['KEEPALIVE_TIMEOUT'] || 65 %>;
   types_hash_max_size 2048;
   client_max_body_size 0;
   underscores_in_headers on;

--- a/templates/etc/nginx/sites-enabled/server.conf.erb
+++ b/templates/etc/nginx/sites-enabled/server.conf.erb
@@ -24,7 +24,7 @@ server {
   listen 80;
   <% end %>
 
-  keepalive_timeout 5;
+  keepalive_timeout <%= ENV['KEEPALIVE_TIMEOUT'] || 5 %>;
 
   error_page 502 503 504 /50x.html;
   location /50x.html {
@@ -88,7 +88,7 @@ server {
   resolver 8.8.8.8 8.8.4.4;
   <% end %>
 
-  keepalive_timeout 5;
+  keepalive_timeout <%= ENV['KEEPALIVE_TIMEOUT'] || 5 %>;
 
   error_page 502 503 504 /50x.html;
   location /50x.html {

--- a/test/connect-keepalive
+++ b/test/connect-keepalive
@@ -1,0 +1,23 @@
+#!/bin/bash
+PROTO="$1"
+SLEEP="$2"
+
+if [[ "$PROTO" = "http" ]]; then
+  COMMAND=(nc localhost 80)
+elif [[ "$PROTO" = "https" ]]; then
+  COMMAND=(openssl s_client -connect localhost:443)
+else
+  echo "Invalid proto: $PROTO"
+  exit 1
+fi
+
+(
+  req="GET / HTTP/1.1\nHost: localhost\n\n"
+  printf "$req"
+  # This isn't super neat... but we need to give our upstream-server time to
+  # restart..!
+  sleep 1
+  printf "$req"
+  sleep "$SLEEP"
+  printf "$req"
+) | "${COMMAND[@]}"


### PR DESCRIPTION
When the KEEPALIVE_TIMEOUT environment variable is set, we'll replace
the default 5 seconds timeout with whatever value was found in there.
This may eventually be exposed to end-users, so we validate that it's an
integer.

---

This is similar to https://github.com/aptible/docker-nginx/pull/77 with a few differences:

- It works for both HTTP and HTTPS
- It doesn't allow a timeout that's not an integer
- It has a few basic tests

cc @fancyremarker @kunwarbhatia