### PR TITLE
Be more patient when waiting for a response

### DIFF
--- a/test/connect-keepalive
+++ b/test/connect-keepalive
@@ -20,6 +20,8 @@ fi
   printf "$req"
   sleep "$SLEEP"
   printf "$req"
+  # And, we need to give Nginx time to respond before we hang up.
+  sleep 1
 ) | "${COMMAND[@]}"
 
 true


### PR DESCRIPTION
Another issue that only appears on Quay. We need to wait a little longer
after sending our payload to Nginx, since otherwise it might error out
with a 499 when we close the connection before Nginx has time to
dispatch it to the upstream.

--

See https://github.com/aptible/docker-nginx/pull/83 for why this has to be a PR (I can't reproduce the issue outside of Quay).