### PR TITLE
Support PROXY_IDLE_TIMEOUT

### DIFF
--- a/templates/bin/nginx-wrapper
+++ b/templates/bin/nginx-wrapper
@@ -30,6 +30,11 @@ if [[ -n "$KEEPALIVE_TIMEOUT" ]] && [[ ! "$KEEPALIVE_TIMEOUT" =~ ^[0-9]+$ ]]; th
   unset KEEPALIVE_TIMEOUT
 fi
 
+if [[ -n "$PROXY_IDLE_TIMEOUT" ]] && [[ ! "$PROXY_IDLE_TIMEOUT" =~ ^[0-9]+$ ]]; then
+  echo "PROXY_IDLE_TIMEOUT=${PROXY_IDLE_TIMEOUT} is not acceptable!" >&2
+  unset PROXY_IDLE_TIMEOUT
+fi
+
 # Process ERB variables in Nginx configuration templates
 cd /etc/nginx && erb nginx.conf.erb > nginx.conf
 cd /etc/nginx/partial && erb health.conf.erb > health.conf

--- a/templates/etc/nginx/sites-enabled/server.conf.erb
+++ b/templates/etc/nginx/sites-enabled/server.conf.erb
@@ -27,6 +27,8 @@ server {
   <% end %>
 
   keepalive_timeout <%= ENV['KEEPALIVE_TIMEOUT'] || 5 %>;
+  proxy_connect_timeout <%= ENV['PROXY_IDLE_TIMEOUT'] || 60 %>;
+  proxy_read_timeout <%= ENV['PROXY_IDLE_TIMEOUT'] || 60 %>;
 
   error_page 502 503 504 /50x.html;
   location /50x.html {
@@ -93,6 +95,8 @@ server {
   <% end %>
 
   keepalive_timeout <%= ENV['KEEPALIVE_TIMEOUT'] || 5 %>;
+  proxy_connect_timeout <%= ENV['PROXY_IDLE_TIMEOUT'] || 60 %>;
+  proxy_read_timeout <%= ENV['PROXY_IDLE_TIMEOUT'] || 60 %>;
 
   error_page 502 503 504 /50x.html;
   location /50x.html {

--- a/test/upstream-server
+++ b/test/upstream-server
@@ -3,11 +3,15 @@
 PORT="${UPSTREAM_PORT:-"4000"}"
 RESPONSE="$BATS_TEST_DIRNAME"/"${UPSTREAM_RESPONSE:-"upstream-response.txt"}"
 OUTPUT="${UPSTREAM_OUT:-"/tmp/$$.log"}"
+DELAY="${UPSTREAM_DELAY:-0}"
 
 # inspired by
 # http://www.commandlinefu.com/commands/view/9164/one-command-line-web-server-on-port-80-using-nc-netcat
 echo > "$OUTPUT"
 while true; do
-  nc -l -p "$PORT" 127.0.0.1 < "$RESPONSE" >> "$OUTPUT"
+  (
+    sleep "$DELAY"
+    cat "$RESPONSE"
+  ) | nc -l -p "$PORT" 127.0.0.1 >> "$OUTPUT"
 done
 rm -f "$OUTPUT"


### PR DESCRIPTION
This lets us configure Nginx so that when it sits behind an ALB, its
idle timeout is lower than the ALB's and therefore Nginx gets to send
the error message if the upstream is timing out (doesn't change anything
to the fact that we're timing out, just changes where the error response
is generated).

---

cc @fancyremarker 