### PR TITLE
Health check: set a X-Aptible-Health-Check header

### DIFF
--- a/templates/etc/nginx/partial/health.conf.erb
+++ b/templates/etc/nginx/partial/health.conf.erb
@@ -5,6 +5,7 @@ location = @healthcheck {
   proxy_pass_request_headers off;
   proxy_pass_request_body off;
   proxy_set_header User-Agent "Aptible Health Check";
+  proxy_set_header X-Aptible-Health-Check 1;
 
   rewrite ^ /healthcheck break;
 

--- a/templates/etc/nginx/sites-enabled/server.conf.erb
+++ b/templates/etc/nginx/sites-enabled/server.conf.erb
@@ -57,6 +57,7 @@ server {
     proxy_set_header Host $http_host;
     proxy_set_header X-Request-Start "t=${msec}";
     proxy_set_header Proxy "";
+    proxy_set_header X-Aptible-Health-Check "";
     proxy_redirect off;
 
     <% if ENV['UPSTREAM_SERVERS'] %>
@@ -119,6 +120,7 @@ server {
     proxy_set_header Host $http_host;
     proxy_set_header X-Request-Start "t=${msec}";
     proxy_set_header Proxy "";
+    proxy_set_header X-Aptible-Health-Check "";
     proxy_redirect off;
 
     <% if ENV['UPSTREAM_SERVERS'] %>
@@ -163,6 +165,7 @@ server {
     proxy_pass_request_headers off;
     proxy_pass_request_body off;
     proxy_set_header User-Agent "Aptible Health Check";
+    proxy_set_header X-Aptible-Health-Check 1;
 
     proxy_pass http://containers;
   }


### PR DESCRIPTION
This lets customers identify whether a request is coming from a health
check or not when it reaches `/healthcheck` on their app.

This is not entirely foolproof considering and end-user can still
request `/.aptible/alb-healthcheck` (for ALB Endpoints).

We should investigate the possibility of black-holing this at the ALB
level, and review whether the ALB actually sends a trustable header
flagging a health check request that we could use here. We could even
have the ALB use a randomized health check path that only works for one
given release. The latter would actually be reasonably easy to
implement, with the caveat that coordinating its release might be a
little complex.

We should probably work on this once we start supporting health checks
where the status code is meaningful (where customers may want decide to
perform infrastructure health checks that end-users should not be
allowed to trigger).

---

cc @fancyremarker 