### PR TITLE
Upgrade OpenSSL to 1.0.2k

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM quay.io/aptible/alpine
+FROM quay.io/aptible/alpine:3.3
+
+RUN apk-install openssl>=1.0.2k
 
 # ruby necessary for ERB
 # curl necessary for integration tests


### PR DESCRIPTION
- CVE-2017-3731
- CVE-2017-3732
- CVE-2016-7055

We're not really vulnerable to any of these, but let's stay up to date!

cc @fancyremarker 