### PR TITLE
http_log: include remote_port

### DIFF
--- a/templates/etc/nginx/nginx.conf.erb
+++ b/templates/etc/nginx/nginx.conf.erb
@@ -30,7 +30,7 @@ http {
                        '"$request" $status $body_bytes_sent $request_time '
                        '"$http_referer" "$http_user_agent"';
 
-  log_format http_log  '$remote_addr $ssl_protocol/$ssl_cipher '
+  log_format http_log  '$remote_addr:$remote_port $ssl_protocol/$ssl_cipher '
                        '$host $remote_user [$time_local] '
                        '"$request" $status $body_bytes_sent $request_time '
                        '"$http_referer" "$http_user_agent"';


### PR DESCRIPTION
When using an ALB, this makes it easier to correlate Nginx logs with ALB
logs.

cc @fancyremarker 