### PR TITLE
Add STRICT_HEALTH_CHECKS to /healthcheck status

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,10 @@ ADD templates/html /usr/html/
 ADD templates/etc /etc
 ADD templates/bin /usr/local/bin
 
-# Generate default 50x.html
+# Generate default error pages
 RUN cd /usr/html \
- && erb 50x.html.erb > 50x.html
+ && ERROR_EMBED_PATH="50x.html.embed" erb error.html.erb > 50x.html \
+ && ERROR_EMBED_PATH="hostname-filtering.html.embed" erb error.html.erb > hostname-filtering.html
 
 RUN mkdir /html
 ADD templates/html/acme-pending.html.erb /html/

--- a/templates/bin/nginx-wrapper
+++ b/templates/bin/nginx-wrapper
@@ -41,6 +41,9 @@ export SSL_KEY_FILE="/etc/nginx/ssl/server.key"
 # Process ERB variables in Nginx configuration templates
 cd /etc/nginx && erb nginx.conf.erb > nginx.conf
 cd /etc/nginx/partial && erb health.conf.erb > health.conf
+cd /etc/nginx/partial && erb server.conf.erb > server.conf
+cd /etc/nginx/partial && erb location.conf.erb > location.conf
+cd /etc/nginx/partial && erb ssl.conf.erb > ssl.conf
 cd /etc/nginx/sites-enabled && erb server.conf.erb > server.conf
 
 if [[ -n "$SSL_CERTIFICATE" ]]; then

--- a/templates/bin/nginx-wrapper
+++ b/templates/bin/nginx-wrapper
@@ -44,6 +44,7 @@ cd /etc/nginx/partial && erb health.conf.erb > health.conf
 cd /etc/nginx/partial && erb server.conf.erb > server.conf
 cd /etc/nginx/partial && erb location.conf.erb > location.conf
 cd /etc/nginx/partial && erb ssl.conf.erb > ssl.conf
+cd /etc/nginx/partial && erb hostname-filtering.conf.erb > hostname-filtering.conf
 cd /etc/nginx/sites-enabled && erb server.conf.erb > server.conf
 
 if [[ -n "$SSL_CERTIFICATE" ]]; then

--- a/templates/etc/nginx/partial/health.conf.erb
+++ b/templates/etc/nginx/partial/health.conf.erb
@@ -23,12 +23,17 @@ location = /.aptible/alb-healthcheck {
     return 200 "";
   <% else %>
     content_by_lua_block {
-    local r = ngx.location.capture("@healthcheck");
-    if r.status == 502 then
-    ngx.status = 502;
-    else
-    ngx.status = 200;
-    end
+      local r = ngx.location.capture("@healthcheck");
+
+      if r.status == 502 then
+        ngx.status = 502;
+      else
+      <% if ENV['STRICT_HEALTH_CHECKS'] == 'true' %>
+        ngx.status = r.status;
+      <% else %>
+        ngx.status = 200;
+      <% end %>
+      end
     }
   <% end %>
 }

--- a/templates/etc/nginx/partial/hostname-filtering.conf.erb
+++ b/templates/etc/nginx/partial/hostname-filtering.conf.erb
@@ -1,0 +1,10 @@
+error_page 400 /hostname-filtering.html;
+
+location = /hostname-filtering.html {
+  root /usr/html;
+  internal;
+}
+
+location / {
+  return 400;
+}

--- a/templates/etc/nginx/partial/location.conf.erb
+++ b/templates/etc/nginx/partial/location.conf.erb
@@ -1,0 +1,21 @@
+<% if ENV['ACME_PENDING'] == 'true' %>
+  rewrite ^ /acme-pending.html break;
+  root /html;
+<% else %>
+
+  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  proxy_set_header Host $http_host;
+  proxy_set_header X-Request-Start "t=${msec}";
+  proxy_set_header Proxy "";
+  proxy_set_header X-Aptible-Health-Check "";
+  proxy_redirect off;
+
+  <% if ENV['UPSTREAM_SERVERS'] %>
+    proxy_pass http://containers;
+
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+  <% end %>
+  break;
+<% end %>

--- a/templates/etc/nginx/partial/server.conf.erb
+++ b/templates/etc/nginx/partial/server.conf.erb
@@ -1,0 +1,29 @@
+<% if ENV['PROXY_PROTOCOL'] == 'true' %>
+  set_real_ip_from 0.0.0.0/0;
+  real_ip_header proxy_protocol;
+  access_log /proc/self/fd/1 proxy_log;
+<% else %>
+  access_log /proc/self/fd/1 http_log;
+<% end %>
+
+<% if ENV['HOSTNAME_FILTERING_SERVER_NAME'] %>
+  server_name <%= ENV.fetch('HOSTNAME_FILTERING_SERVER_NAME') %>;
+<% end %>
+
+keepalive_timeout <%= ENV['KEEPALIVE_TIMEOUT'] || 5 %>;
+proxy_connect_timeout <%= ENV['PROXY_IDLE_TIMEOUT'] || 60 %>;
+proxy_read_timeout <%= ENV['PROXY_IDLE_TIMEOUT'] || 60 %>;
+
+error_page 502 503 504 /50x.html;
+location /50x.html {
+}
+
+<% if ENV['ACME_SERVER'] %>
+  location /.well-known/acme-challenge {
+  proxy_pass http://acme;
+  }
+<% elsif ENV['ACME_REDIRECT_HOST'] %>
+  location /.well-known/acme-challenge {
+  return 301 $scheme://<%= ENV.fetch('ACME_REDIRECT_HOST') %>$request_uri;
+  }
+<% end %>

--- a/templates/etc/nginx/partial/ssl.conf.erb
+++ b/templates/etc/nginx/partial/ssl.conf.erb
@@ -1,0 +1,8 @@
+ssl on;
+ssl_certificate <%= ENV.fetch('SSL_CERTIFICATE_FILE') %>;
+ssl_certificate_key <%= ENV.fetch('SSL_KEY_FILE') %>;
+
+<% if ENV['ACME_READY'] == 'true' %>
+  ssl_stapling on;
+  resolver 8.8.8.8 8.8.4.4;
+<% end %>

--- a/templates/etc/nginx/sites-enabled/server.conf.erb
+++ b/templates/etc/nginx/sites-enabled/server.conf.erb
@@ -1,7 +1,7 @@
 <% if ENV['UPSTREAM_SERVERS'] %>
 upstream containers {
   <% (ENV['UPSTREAM_SERVERS']).split(',').each do |server| %>
-  server <%= server %>;
+    server <%= server %>;
   <% end %>
 }
 <% end %>
@@ -13,141 +13,64 @@ upstream acme {
 <% end %>
 
 server {
-  <% if ENV['PROXY_PROTOCOL'] == 'true' %>
-  listen 80 proxy_protocol;
+  listen 80 <%= 'proxy_protocol' if ENV['PROXY_PROTOCOL'] == 'true' %>;
 
-  set_real_ip_from 0.0.0.0/0;
-  real_ip_header proxy_protocol;
-
-  access_log /proc/self/fd/1 proxy_log;
-  <% else %>
-  listen 80;
-
-  access_log /proc/self/fd/1 http_log;
-  <% end %>
-
-  keepalive_timeout <%= ENV['KEEPALIVE_TIMEOUT'] || 5 %>;
-  proxy_connect_timeout <%= ENV['PROXY_IDLE_TIMEOUT'] || 60 %>;
-  proxy_read_timeout <%= ENV['PROXY_IDLE_TIMEOUT'] || 60 %>;
-
-  error_page 502 503 504 /50x.html;
-  location /50x.html {
-  }
-
-  <% if ENV['ACME_SERVER'] %>
-  location /.well-known/acme-challenge {
-    proxy_pass http://acme;
-  }
-  <% elsif ENV['ACME_REDIRECT_HOST'] %>
-  location /.well-known/acme-challenge {
-    return 301 $scheme://<%= ENV.fetch('ACME_REDIRECT_HOST') %>$request_uri;
-  }
-  <% end %>
-
+  include /etc/nginx/partial/server.conf;
   include /etc/nginx/partial/health.conf;
 
   location / {
-    <% if ENV['ACME_PENDING'] == 'true' %>
-    rewrite ^ /acme-pending.html break;
-    root /html;
-    <% else %>
-
-    <% if ENV['FORCE_SSL'] == 'true' %>
-    return 301 https://$host$request_uri;
-    <% end %>
-
+  <% if ENV['FORCE_SSL'] == 'true' %>
+      return 301 https://$host$request_uri;
+  <% else %>
     proxy_set_header X-Forwarded-Proto http;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header Host $http_host;
-    proxy_set_header X-Request-Start "t=${msec}";
-    proxy_set_header Proxy "";
-    proxy_set_header X-Aptible-Health-Check "";
-    proxy_redirect off;
-
-    <% if ENV['UPSTREAM_SERVERS'] %>
-    proxy_pass http://containers;
-
-    proxy_http_version 1.1;
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection "upgrade";
-    <% end %>
-    break;
-    <% end %>
+    include /etc/nginx/partial/location.conf;
+  <% end %>
   }
 }
 
 server {
-  <% if ENV['PROXY_PROTOCOL'] == 'true' %>
-  listen 443 proxy_protocol;
-
-  set_real_ip_from 0.0.0.0/0;
-  real_ip_header proxy_protocol;
-
-  access_log /proc/self/fd/1 proxy_log;
-  <% else %>
-  listen 443;
-
-  access_log /proc/self/fd/1 http_log;
-  <% end %>
-
-  ssl on;
-  ssl_certificate <%= ENV.fetch('SSL_CERTIFICATE_FILE') %>;
-  ssl_certificate_key <%= ENV.fetch('SSL_KEY_FILE') %>;
-
-  <% if ENV['ACME_READY'] == 'true' %>
-  ssl_stapling on;
-  resolver 8.8.8.8 8.8.4.4;
-  <% end %>
-
-  keepalive_timeout <%= ENV['KEEPALIVE_TIMEOUT'] || 5 %>;
-  proxy_connect_timeout <%= ENV['PROXY_IDLE_TIMEOUT'] || 60 %>;
-  proxy_read_timeout <%= ENV['PROXY_IDLE_TIMEOUT'] || 60 %>;
-
-  error_page 502 503 504 /50x.html;
-  location /50x.html {
-  }
+  listen 443 <%= 'proxy_protocol' if ENV['PROXY_PROTOCOL'] == 'true' %>;
 
   <% if ENV['FORCE_SSL'] == 'true' %>
-  add_header Strict-Transport-Security "max-age=<%= ENV['HSTS_MAX_AGE'] || 31536000 %>" always;
+    add_header Strict-Transport-Security "max-age=<%= ENV['HSTS_MAX_AGE'] || 31536000 %>" always;
   <% end %>
 
-  <% if ENV['ACME_SERVER'] %>
-  location /.well-known/acme-challenge {
-    proxy_pass http://acme;
-  }
-  <% elsif ENV['ACME_REDIRECT_HOST'] %>
-  location /.well-known/acme-challenge {
-    return 301 $scheme://<%= ENV.fetch('ACME_REDIRECT_HOST') %>$request_uri;
-  }
-  <% end %>
-
+  include /etc/nginx/partial/server.conf;
+  include /etc/nginx/partial/ssl.conf;
   include /etc/nginx/partial/health.conf;
 
   location / {
-    <% if ENV['ACME_PENDING'] %>
-    rewrite ^ /acme-pending.html break;
-    root /html;
-    <% else %>
-
     proxy_set_header X-Forwarded-Proto https;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header Host $http_host;
-    proxy_set_header X-Request-Start "t=${msec}";
-    proxy_set_header Proxy "";
-    proxy_set_header X-Aptible-Health-Check "";
-    proxy_redirect off;
-
-    <% if ENV['UPSTREAM_SERVERS'] %>
-    proxy_pass http://containers;
-
-    proxy_http_version 1.1;
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection "upgrade";
-    <% end %>
-    break;
-    <% end %>
+    include /etc/nginx/partial/location.conf;
   }
 }
+
+<% if ENV['HOSTNAME_FILTERING_SERVER_NAME'] %>
+  server {
+    listen 80 default_server <%= 'proxy_protocol' if ENV['PROXY_PROTOCOL'] == 'true' %>;
+
+    include /etc/nginx/partial/health.conf;
+
+    location / {
+      return 444;
+    }
+  }
+
+  server {
+    # NOTE: This server leaks the hostname by using the same SSL certificate as
+    # the "real" server. That is fine on Enclave because clients are not
+    # connecting directly to Nginx. That said, we should perhaps allow passing
+    # 2 certificates here: a default, and one for SNI.
+    listen 443 default_server <%= 'proxy_protocol' if ENV['PROXY_PROTOCOL'] == 'true' %>;
+
+    include /etc/nginx/partial/ssl.conf;
+    include /etc/nginx/partial/health.conf;
+
+    location / {
+      return 444;
+    }
+  }
+<% end %>
 
 <% if ENV['UPSTREAM_SERVERS'] %>
 server {

--- a/templates/etc/nginx/sites-enabled/server.conf.erb
+++ b/templates/etc/nginx/sites-enabled/server.conf.erb
@@ -80,10 +80,15 @@ server {
     <% else %>
     content_by_lua_block {
       local r = ngx.location.capture("/healthcheck");
+
       if r.status == 502 then
         ngx.status = 502;
       else
+      <% if ENV['STRICT_HEALTH_CHECKS'] == 'true' %>
+        ngx.status = r.status;
+      <% else %>
         ngx.status = 200;
+      <% end %>
       end
     }
     <% end %>

--- a/templates/etc/nginx/sites-enabled/server.conf.erb
+++ b/templates/etc/nginx/sites-enabled/server.conf.erb
@@ -50,10 +50,7 @@ server {
     listen 80 default_server <%= 'proxy_protocol' if ENV['PROXY_PROTOCOL'] == 'true' %>;
 
     include /etc/nginx/partial/health.conf;
-
-    location / {
-      return 444;
-    }
+    include /etc/nginx/partial/hostname-filtering.conf;
   }
 
   server {
@@ -65,10 +62,7 @@ server {
 
     include /etc/nginx/partial/ssl.conf;
     include /etc/nginx/partial/health.conf;
-
-    location / {
-      return 444;
-    }
+    include /etc/nginx/partial/hostname-filtering.conf;
   }
 <% end %>
 

--- a/templates/html/50x.html.embed
+++ b/templates/html/50x.html.embed
@@ -1,0 +1,10 @@
+<h1>This application crashed</h1>
+
+<p>
+If you are a visitor, please try again shortly.
+</p>
+
+<p>
+If you are the owner of this application, check your logs for
+errors, or restart your app.
+</p>

--- a/templates/html/error.html.erb
+++ b/templates/html/error.html.erb
@@ -1,4 +1,5 @@
 <% require 'base64' %>
+
 <!DOCTYPE html>
 <html>
   <head>
@@ -56,16 +57,7 @@
         <div class="error-body">
           <div class="error-logo"></div>
 
-          <h1>This application crashed</h1>
-
-          <p>
-          If you are a visitor, please try again shortly.
-          </p>
-
-          <p>
-          If you are the owner of this application, check your logs for
-          errors, or restart your app.
-          </p>
+          <%= File.read(ENV.fetch('ERROR_EMBED_PATH')) %>
         </div>
       </div>
     </div>

--- a/templates/html/hostname-filtering.html.embed
+++ b/templates/html/hostname-filtering.html.embed
@@ -1,0 +1,11 @@
+<h1>This request was blocked by Hostname Filtering</h1>
+
+<p>
+This means your request used a hostname different from the one you used when
+configuring this Endpoint and enabled Hostname Filtering.
+</p>
+
+<p>
+Make sure you are using the hostname you specified when creating this Endpoint
+to connect.
+</p>

--- a/test/nginx.bats
+++ b/test/nginx.bats
@@ -498,81 +498,81 @@ NGINX_VERSION=1.10.1
   [[ "$output" =~ "Strict-Transport-Security:" ]]
 }
 
-HEALTH_PORT="Port 9000"
+HEALTH_PORT="9000"
 
-@test "${HEALTH_PORT}: Nginx accepts plain HTTP requests" {
+@test "Port ${HEALTH_PORT}: Nginx accepts plain HTTP requests" {
   simulate_upstream
   PROXY_PROTOCOL=true UPSTREAM_SERVERS=localhost:4000 wait_for_nginx
 
-  curl -fs http://localhost:9000/
+  curl -fs "http://localhost:${HEALTH_PORT}/"
   wait_for grep -i 'get' "$UPSTREAM_OUT"
 }
 
-@test "${HEALTH_PORT} Nginx rewrites the request path to /healthcheck" {
+@test "Port ${HEALTH_PORT}: Nginx rewrites the request path to /healthcheck" {
   simulate_upstream
   PROXY_PROTOCOL=true UPSTREAM_SERVERS=localhost:4000 wait_for_nginx
 
-  curl -fs http://localhost:9000/foo
+  curl -fs "http://localhost:${HEALTH_PORT}/foo"
   wait_for grep 'GET /healthcheck' "$UPSTREAM_OUT"
 
   run grep -i 'foo' "$UPSTREAM_OUT"
   [[ "$status" -eq 1 ]]
 }
 
-@test "${HEALTH_PORT} Nginx discards headers" {
+@test "Port ${HEALTH_PORT}: Nginx discards headers" {
   simulate_upstream
   PROXY_PROTOCOL=true UPSTREAM_SERVERS=localhost:4000 wait_for_nginx
 
-  curl -fs -H 'Authorization: foo' http://localhost:9000/
+  curl -fs -H 'Authorization: foo' "http://localhost:${HEALTH_PORT}/"
   wait_for grep -i 'get' "$UPSTREAM_OUT"
 
   run grep -i 'foo' "$UPSTREAM_OUT"
   [[ "$status" -eq 1 ]]
 }
 
-@test "${HEALTH_PORT} Nginx sets X-Aptible-Health-Check" {
+@test "Port ${HEALTH_PORT}: Nginx sets X-Aptible-Health-Check" {
   simulate_upstream
   PROXY_PROTOCOL=true UPSTREAM_SERVERS=localhost:4000 wait_for_nginx
 
-  curl -fs http://localhost:9000/
+  curl -fs "http://localhost:${HEALTH_PORT}/"
   wait_for grep -i 'get' "$UPSTREAM_OUT"
 
   grep -i 'X-Aptible-Health-Check' "$UPSTREAM_OUT"
 }
 
-@test "${HEALTH_PORT} Nginx rewrites the User-Agent header to Aptible Health Check" {
+@test "Port ${HEALTH_PORT}: Nginx rewrites the User-Agent header to Aptible Health Check" {
   simulate_upstream
   PROXY_PROTOCOL=true UPSTREAM_SERVERS=localhost:4000 wait_for_nginx
 
-  curl -fs http://localhost:9000/
+  curl -fs "http://localhost:${HEALTH_PORT}/"
   wait_for grep -i 'get' "$UPSTREAM_OUT"
 
   grep 'Aptible Health Check' "$UPSTREAM_OUT"
 }
 
-@test "${HEALTH_PORT} Nginx discards the request body" {
+@test "Port ${HEALTH_PORT}: Nginx discards the request body" {
   simulate_upstream
   PROXY_PROTOCOL=true UPSTREAM_SERVERS=localhost:4000 wait_for_nginx
 
-  curl -fs --data "foo=bar" http://localhost:9000/
+  curl -fs --data "foo=bar" "http://localhost:${HEALTH_PORT}/"
   wait_for grep -i 'get' "$UPSTREAM_OUT"
 
   run grep -i 'foo' "$UPSTREAM_OUT"
   [[ "$status" -eq 1 ]]
 }
 
-@test "${HEALTH_PORT} Nginx discards the request method" {
+@test "Port ${HEALTH_PORT}: Nginx discards the request method" {
   simulate_upstream
   PROXY_PROTOCOL=true UPSTREAM_SERVERS=localhost:4000 wait_for_nginx
 
-  curl -fs -I http://localhost:9000/
+  curl -fs -I "http://localhost:${HEALTH_PORT}/"
   wait_for grep -i 'get' "$UPSTREAM_OUT"
 
   run grep -i 'head' "$UPSTREAM_OUT"
   [[ "$status" -eq 1 ]]
 }
 
-@test "${HEALTH_PORT} Nginx discards the response body" {
+@test "Port ${HEALTH_PORT}: Nginx discards the response body" {
   simulate_upstream
   PROXY_PROTOCOL=true UPSTREAM_SERVERS=localhost:4000 wait_for_nginx
   wait_for_proxy_protocol
@@ -580,38 +580,65 @@ HEALTH_PORT="Port 9000"
   run curl http://localhost:8080/
   [[ "$output" =~ "Hello World!" ]]
 
-  run curl http://localhost:9000/
+  run curl "http://localhost:${HEALTH_PORT}/"
   [[ ! "$output" =~ "Hello World!" ]]
 }
 
-@test "${HEALTH_PORT} Nginx returns a 502 if the upstream is not responding" {
+@test "Port ${HEALTH_PORT}: Nginx returns a 502 if the upstream is not responding" {
   PROXY_PROTOCOL=true UPSTREAM_SERVERS=localhost:4000 wait_for_nginx
 
-  run curl -sw "%{http_code}" http://localhost:9000/
+  run curl -sw "%{http_code}" "http://localhost:${HEALTH_PORT}/"
   [[ "$output" -eq 502 ]]
 }
 
-@test "${HEALTH_PORT} Nginx returns a 200 if the upstream is returning a 200" {
+@test "Port ${HEALTH_PORT}: Nginx returns a 200 if the upstream is returning a 200" {
   UPSTREAM_RESPONSE="upstream-response.txt" simulate_upstream
   PROXY_PROTOCOL=true UPSTREAM_SERVERS=localhost:4000 wait_for_nginx
 
-  run curl -sw "%{http_code}" http://localhost:9000/
+  run curl -sw "%{http_code}" "http://localhost:${HEALTH_PORT}/"
   [[ "$output" -eq 200 ]]
 }
 
-@test "${HEALTH_PORT} Nginx returns a 200 if the upstream is returning a 500" {
+@test "Port ${HEALTH_PORT}: Nginx returns a 200 if the upstream is returning a 500" {
   UPSTREAM_RESPONSE="upstream-response-500.txt" simulate_upstream
   PROXY_PROTOCOL=true UPSTREAM_SERVERS=localhost:4000 wait_for_nginx
 
-  run curl -sw "%{http_code}" http://localhost:9000/
+  run curl -sw "%{http_code}" "http://localhost:${HEALTH_PORT}/"
   [[ "$output" -eq 200 ]]
 }
 
-@test "${HEALTH_PORT} Nginx returns a 200 if FORCE_HEALTHCHECK_SUCCESS = true" {
+@test "Port ${HEALTH_PORT}: Nginx returns a 200 if FORCE_HEALTHCHECK_SUCCESS = true" {
   FORCE_HEALTHCHECK_SUCCESS=true PROXY_PROTOCOL=true UPSTREAM_SERVERS=localhost:4000 wait_for_nginx
 
-  run curl -sw "%{http_code}" http://localhost:9000/
+  run curl -sw "%{http_code}" "http://localhost:${HEALTH_PORT}/"
   [[ "$output" -eq 200 ]]
+}
+
+@test "Port ${HEALTH_PORT}: Nginx supports STRICT_HEALTH_CHECKS = true (200)" {
+  simulate_upstream
+  STRICT_HEALTH_CHECKS=true PROXY_PROTOCOL=true UPSTREAM_SERVERS=localhost:4000 wait_for_nginx
+  wait_for_proxy_protocol
+
+  status="$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:${HEALTH_PORT}")"
+  [[ "$status" == "200" ]]
+}
+
+@test "Port ${HEALTH_PORT}: Nginx supports STRICT_HEALTH_CHECKS = true (302)" {
+  UPSTREAM_RESPONSE="upstream-response-302.txt" simulate_upstream
+  STRICT_HEALTH_CHECKS=true PROXY_PROTOCOL=true UPSTREAM_SERVERS=localhost:4000 wait_for_nginx
+  wait_for_proxy_protocol
+
+  status="$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:${HEALTH_PORT}")"
+  [[ "$status" == "302" ]]
+}
+
+@test "Port ${HEALTH_PORT}: Nginx supports STRICT_HEALTH_CHECKS = true (500)" {
+  UPSTREAM_RESPONSE="upstream-response-500.txt" simulate_upstream
+  STRICT_HEALTH_CHECKS=true PROXY_PROTOCOL=true UPSTREAM_SERVERS=localhost:4000 wait_for_nginx
+  wait_for_proxy_protocol
+
+  status="$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:${HEALTH_PORT}")"
+  [[ "$status" == "500" ]]
 }
 
 HEALTH_ROUTE=.aptible/alb-healthcheck
@@ -730,15 +757,28 @@ HEALTH_ROUTE=.aptible/alb-healthcheck
   [[ "$output" -eq 200 ]]
 }
 
-@test "${HEALTH_ROUTE} (HTTPS): Nginx rewrites the request path to /healthcheck" {
+@test "${HEALTH_ROUTE} (HTTP): Nginx supports STRICT_HEALTH_CHECKS = true (200)" {
   simulate_upstream
-  UPSTREAM_SERVERS=localhost:4000 wait_for_nginx
+  STRICT_HEALTH_CHECKS=true UPSTREAM_SERVERS=localhost:4000 wait_for_nginx
 
-  curl -fsk "https://localhost/${HEALTH_ROUTE}"
-  wait_for grep 'GET /healthcheck' "$UPSTREAM_OUT"
+  status="$(curl -s -o /dev/null -w "%{http_code}" "http://localhost/${HEALTH_ROUTE}")"
+  [[ "$status" == "200" ]]
+}
 
-  run grep -Fi '.aptible' "$UPSTREAM_OUT"
-  [[ "$status" -eq 1 ]]
+@test "${HEALTH_ROUTE} (HTTP): Nginx supports STRICT_HEALTH_CHECKS = true (302)" {
+  UPSTREAM_RESPONSE="upstream-response-302.txt" simulate_upstream
+  STRICT_HEALTH_CHECKS=true UPSTREAM_SERVERS=localhost:4000 wait_for_nginx
+
+  status="$(curl -s -o /dev/null -w "%{http_code}" "http://localhost/${HEALTH_ROUTE}")"
+  [[ "$status" == "302" ]]
+}
+
+@test "${HEALTH_ROUTE} (HTTP): Nginx supports STRICT_HEALTH_CHECKS = true (500)" {
+  UPSTREAM_RESPONSE="upstream-response-500.txt" simulate_upstream
+  STRICT_HEALTH_CHECKS=true UPSTREAM_SERVERS=localhost:4000 wait_for_nginx
+
+  status="$(curl -s -o /dev/null -w "%{http_code}" "http://localhost/${HEALTH_ROUTE}")"
+  [[ "$status" == "500" ]]
 }
 
 @test "${HEALTH_ROUTE} (HTTPS): Nginx discards headers" {
@@ -834,6 +874,41 @@ HEALTH_ROUTE=.aptible/alb-healthcheck
 
   run curl -skw "%{http_code}" "https://localhost/${HEALTH_ROUTE}"
   [[ "$output" -eq 200 ]]
+}
+
+@test "${HEALTH_ROUTE} (HTTPS): Nginx supports STRICT_HEALTH_CHECKS = true (200)" {
+  simulate_upstream
+  STRICT_HEALTH_CHECKS=true UPSTREAM_SERVERS=localhost:4000 wait_for_nginx
+
+  status="$(curl -k -s -o /dev/null -w "%{http_code}" "https://localhost/${HEALTH_ROUTE}")"
+  [[ "$status" == "200" ]]
+}
+
+@test "${HEALTH_ROUTE} (HTTPS): Nginx supports STRICT_HEALTH_CHECKS = true (302)" {
+  UPSTREAM_RESPONSE="upstream-response-302.txt" simulate_upstream
+  STRICT_HEALTH_CHECKS=true UPSTREAM_SERVERS=localhost:4000 wait_for_nginx
+
+  status="$(curl -k -s -o /dev/null -w "%{http_code}" "https://localhost/${HEALTH_ROUTE}")"
+  [[ "$status" == "302" ]]
+}
+
+@test "${HEALTH_ROUTE} (HTTPS): Nginx supports STRICT_HEALTH_CHECKS = true (500)" {
+  UPSTREAM_RESPONSE="upstream-response-500.txt" simulate_upstream
+  STRICT_HEALTH_CHECKS=true UPSTREAM_SERVERS=localhost:4000 wait_for_nginx
+
+  status="$(curl -k -s -o /dev/null -w "%{http_code}" "https://localhost/${HEALTH_ROUTE}")"
+  [[ "$status" == "500" ]]
+}
+
+@test "${HEALTH_ROUTE} (HTTPS): Nginx rewrites the request path to /healthcheck" {
+  simulate_upstream
+  UPSTREAM_SERVERS=localhost:4000 wait_for_nginx
+
+  curl -fsk "https://localhost/${HEALTH_ROUTE}"
+  wait_for grep 'GET /healthcheck' "$UPSTREAM_OUT"
+
+  run grep -Fi '.aptible' "$UPSTREAM_OUT"
+  [[ "$status" -eq 1 ]]
 }
 
 @test "it applies a default KEEPALIVE_TIMEOUT of 5 seconds (HTTP)" {

--- a/test/upstream-response-302.txt
+++ b/test/upstream-response-302.txt
@@ -1,0 +1,6 @@
+HTTP/1.1 302 Found
+Content-Type: application/json
+Content-Length: 37
+Location: http://example.com/redirect
+
+{ "message": "See you other there!" }


### PR DESCRIPTION
This adds a STRICT_HEALTH_CHECKS option to passthrough the status code
from the `/healthcheck` route returned by the upstream. This will allow
customers to opt in to strict health checking in their apps, as opposed
to allowing any response.

---

Note: I've based this on #95 because of some refactoring of our Nginx configuration I've done there. Only the last commit here is for this feature.

cc @fancyremarker 
