### PR TITLE
ALB: debounce health check requests

### DIFF
--- a/templates/etc/nginx/nginx.conf.erb
+++ b/templates/etc/nginx/nginx.conf.erb
@@ -52,6 +52,8 @@ http {
 
   server_tokens off;
 
+  lua_shared_dict health 128k;
+
   include /etc/nginx/conf.d/*.conf;
   include /etc/nginx/sites-enabled/*.conf;
 }

--- a/templates/etc/nginx/partial/health.conf.erb
+++ b/templates/etc/nginx/partial/health.conf.erb
@@ -23,17 +23,75 @@ location = /.aptible/alb-healthcheck {
     return 200 "";
   <% else %>
     content_by_lua_block {
-      local r = ngx.location.capture("@healthcheck");
+      function setStatusFromCache()
+        local cachedStatus, cachedStatusFlags = ngx.shared.health:get("status")
 
-      if r.status == 502 then
-        ngx.status = 502;
-      else
-      <% if ENV['STRICT_HEALTH_CHECKS'] == 'true' %>
-        ngx.status = r.status;
-      <% else %>
-        ngx.status = 200;
-      <% end %>
+        if cachedStatus then
+          ngx.log(ngx.INFO, "health: status from cache: " .. cachedStatus)
+          ngx.status = cachedStatus
+          ngx.say("cache:" .. cachedStatus)
+          return true
+        end
+
+        -- Second return value is actually the error here
+        if cachedStatusFlags then
+          ngx.log(ngx.ERROR, "health: status error: " .. cachedStatusFlags)
+        end
+
+        ngx.log(ngx.DEBUG, "health: no cache")
+
+        return false
       end
+
+      function setStatus()
+        if setStatusFromCache() then
+          return
+        end
+
+        -- If another request is currently running the health check,
+        -- wait a little before checking the cache again.
+        local hold, holdFlags = ngx.shared.health:get("hold")
+        if hold then
+          ngx.log(ngx.DEBUG, "health: hold")
+          ngx.sleep(1)
+          if setStatusFromCache() then
+            return
+          end
+        end
+
+        -- Tell other requests coming in during the next 2 seconds to hold while
+        -- we run the health check.
+        local holdOk, holdErr = ngx.shared.health:safe_set("hold", true, 2)
+        if not holdOk then
+          ngx.log(ngx.ERROR, "health: failed to set hold: " .. holdErr)
+        end
+
+        -- Make the actual upstream request
+        local r = ngx.location.capture("@healthcheck")
+        local upstreamStatus = r.status
+
+        -- Record our resulting status, make this valid for 5 seconds.
+        local statusOk, statusErr, forcible = ngx.shared.health:set("status", upstreamStatus, 5)
+        if not statusOk then
+          ngx.log(ngx.ERROR, "health: failed to set status: " .. statusErr)
+        end
+
+        ngx.log(ngx.INFO, "health: status from upstream: " .. upstreamStatus)
+
+        if upstreamStatus == 502 then
+          ngx.status = 502
+        else
+        <% if ENV['STRICT_HEALTH_CHECKS'] == 'true' %>
+          ngx.status = upstreamStatus
+        <% else %>
+          ngx.status = 200
+        <% end %>
+        end
+
+        ngx.say("upstream:" .. upstreamStatus)
+      end
+
+      setStatus()
     }
   <% end %>
 }

--- a/templates/etc/nginx/partial/health.conf.erb
+++ b/templates/etc/nginx/partial/health.conf.erb
@@ -68,7 +68,19 @@ location = /.aptible/alb-healthcheck {
 
         -- Make the actual upstream request
         local r = ngx.location.capture("@healthcheck")
-        local upstreamStatus = r.status
+
+        -- Decide what this status means
+        local upstreamStatus
+
+        if r.status == 502 then
+          upstreamStatus = r.status
+        else
+        <% if ENV['STRICT_HEALTH_CHECKS'] == 'true' %>
+          upstreamStatus = r.status
+        <% else %>
+          upstreamStatus = 200
+        <% end %>
+        end
 
         -- Record our resulting status, make this valid for 5 seconds.
         local statusOk, statusErr, forcible = ngx.shared.health:set("status", upstreamStatus, 5)
@@ -76,18 +88,10 @@ location = /.aptible/alb-healthcheck {
           ngx.log(ngx.ERROR, "health: failed to set status: " .. statusErr)
         end
 
-        ngx.log(ngx.INFO, "health: status from upstream: " .. upstreamStatus)
+        ngx.log(ngx.INFO, "health: derived status from upstream: " .. upstreamStatus)
+        ngx.log(ngx.DEBUG, "health: real status from upstream: " .. r.status)
 
-        if upstreamStatus == 502 then
-          ngx.status = 502
-        else
-        <% if ENV['STRICT_HEALTH_CHECKS'] == 'true' %>
-          ngx.status = upstreamStatus
-        <% else %>
-          ngx.status = 200
-        <% end %>
-        end
-
+        ngx.status = upstreamStatus
         ngx.say("upstream:" .. upstreamStatus)
       end
 

--- a/test/nginx.bats
+++ b/test/nginx.bats
@@ -965,7 +965,6 @@ HEALTH_ROUTE=.aptible/alb-healthcheck
 @test "it applies a default KEEPALIVE_TIMEOUT of 5 seconds (HTTP)" {
   simulate_upstream
   UPSTREAM_SERVERS=localhost:4000 wait_for_nginx
-  wait_for_proxy_protocol
 
   # We're going to make 3 requests, but the last request will come in 8 seconds
   # after the second one. As a result, we should only see 2 requests on the
@@ -982,7 +981,6 @@ HEALTH_ROUTE=.aptible/alb-healthcheck
 @test "it applies a default KEEPALIVE_TIMEOUT of 5 seconds (HTTPS)" {
   simulate_upstream
   UPSTREAM_SERVERS=localhost:4000 wait_for_nginx
-  wait_for_proxy_protocol
 
   # Same as above
   "${BATS_TEST_DIRNAME}/connect-keepalive" https 8
@@ -996,7 +994,6 @@ HEALTH_ROUTE=.aptible/alb-healthcheck
 @test "it allows setting a custom KEEPALIVE_TIMEOUT (HTTP)" {
   simulate_upstream
   KEEPALIVE_TIMEOUT=60 UPSTREAM_SERVERS=localhost:4000 wait_for_nginx
-  wait_for_proxy_protocol
 
   # This time, we should see all 3 requests
   "${BATS_TEST_DIRNAME}/connect-keepalive" http 8
@@ -1010,7 +1007,6 @@ HEALTH_ROUTE=.aptible/alb-healthcheck
 @test "it allows setting a custom KEEPALIVE_TIMEOUT (HTTPS)" {
   simulate_upstream
   KEEPALIVE_TIMEOUT=60 UPSTREAM_SERVERS=localhost:4000 wait_for_nginx
-  wait_for_proxy_protocol
 
   # This time, we should see all 3 requests
   "${BATS_TEST_DIRNAME}/connect-keepalive" https 8

--- a/test/upstream-server
+++ b/test/upstream-server
@@ -1,17 +1,42 @@
-#!/bin/sh
+#!/usr/bin/env ruby
+require 'socket'
+require 'thread'
 
-PORT="${UPSTREAM_PORT:-"4000"}"
-RESPONSE="$BATS_TEST_DIRNAME"/"${UPSTREAM_RESPONSE:-"upstream-response.txt"}"
-OUTPUT="${UPSTREAM_OUT:-"/tmp/$$.log"}"
-DELAY="${UPSTREAM_DELAY:-0}"
+Thread.abort_on_exception = true
 
-# inspired by
-# http://www.commandlinefu.com/commands/view/9164/one-command-line-web-server-on-port-80-using-nc-netcat
-echo > "$OUTPUT"
-while true; do
-  (
-    sleep "$DELAY"
-    cat "$RESPONSE"
-  ) | nc -l -p "$PORT" 127.0.0.1 >> "$OUTPUT"
-done
-rm -f "$OUTPUT"
+PORT = Integer(ENV.fetch('UPSTREAM_PORT', '4000'))
+RESPONSE = File.read(
+  File.join(
+    ENV.fetch('BATS_TEST_DIRNAME'),
+    ENV.fetch('UPSTREAM_RESPONSE', 'upstream-response.txt')
+  )
+)
+OUTPUT = ENV.fetch('UPSTREAM_OUT', "/tmp/#{Process.pid}.log")
+DELAY = if (d = ENV['UPSTREAM_DELAY'])
+          d.to_f
+        end
+
+puts "Logging to #{OUTPUT}"
+
+out = File.new(OUTPUT, 'w')
+
+server = TCPServer.new(PORT)
+mutex = Mutex.new
+
+loop do
+  Thread.start(server.accept) do |client|
+    lines = []
+    client.each_line do |l|
+      # We break at the first CRLF, which is the end of headers.
+      lines << l
+      break if l == "\r\n"
+    end
+    mutex.synchronize do
+      lines.each { |l| out.write(l) }
+      out.flush
+    end
+    sleep DELAY if DELAY
+    client.print(RESPONSE)
+    client.close
+  end
+end

--- a/test/upstream-server
+++ b/test/upstream-server
@@ -25,18 +25,25 @@ mutex = Mutex.new
 
 loop do
   Thread.start(server.accept) do |client|
-    lines = []
-    client.each_line do |l|
-      # We break at the first CRLF, which is the end of headers.
-      lines << l
-      break if l == "\r\n"
+    begin
+      loop do
+        lines = []
+        client.each_line do |l|
+          # We break at the first CRLF, which is the end of headers.
+          lines << l
+          break if l == "\r\n"
+        end
+        mutex.synchronize do
+          lines.each { |l| out.write(l) }
+          out.flush
+        end
+        sleep DELAY if DELAY
+        client.print(RESPONSE)
+      end
+    rescue Errno::EPIPE
+      # No-op
+    ensure
+      client.close
     end
-    mutex.synchronize do
-      lines.each { |l| out.write(l) }
-      out.flush
-    end
-    sleep DELAY if DELAY
-    client.print(RESPONSE)
-    client.close
   end
 end


### PR DESCRIPTION
This extends a our LUA-based health check to debounce health checks by
caching the status of the last health check for 5 seconds, and waiting
on running health checks for up to 1 second (it's pretty common for
health checks to all come in rapid succession, so only caching wouldn't
be ideal here).

The goal here is to limit the number of health health checks the
underlying app containers see. For example, this can merge the HTTP and
HTTPS health checks for a single container into a single request.

As part of this, I also rewrote the dummy upstream we use in tests to a
Ruby threaded implementation as opposed to the sequential nc-based
implementation we had until now. The main benefit is that it's not racy:
if a request comes in before we handle the current one, we don't drop it
to the floor. This was necessary to exercise how debouncing works when
concurrent requests are coming in and we don't have a status cached.

---

cc @fancyremarker 