### PR TITLE
Support disabling the ingore_invalid_headers directive

### DIFF
--- a/templates/etc/nginx/nginx.conf.erb
+++ b/templates/etc/nginx/nginx.conf.erb
@@ -14,6 +14,7 @@ http {
   types_hash_max_size 2048;
   client_max_body_size 0;
   underscores_in_headers on;
+  ignore_invalid_headers <%= ENV['IGNORE_INVALID_HEADERS'] || "on" %>;
 
   # Allow for large headers
   large_client_header_buffers 4 32k;

--- a/test/nginx.bats
+++ b/test/nginx.bats
@@ -285,6 +285,24 @@ NGINX_VERSION=1.15.8
   [ "$status" -eq 0 ]
 }
 
+@test "It ignores invalid headers by default" {
+  rm /tmp/nc.log || true
+  nc -l -p 4000 127.0.0.1 > /tmp/nc.log &
+  UPSTREAM_SERVERS=127.0.0.1:4000 wait_for_nginx
+  curl --header "Periods.Are.Invalid: true" --max-time 1 http://localhost
+  run cat /tmp/nc.log
+  [[ ! "$output" =~ "Periods.Are.Invalid: true" ]]
+}
+
+@test "It can allow invalid headers" {
+  rm /tmp/nc.log || true
+  nc -l -p 4000 127.0.0.1 > /tmp/nc.log &
+  IGNORE_INVALID_HEADERS=off UPSTREAM_SERVERS=127.0.0.1:4000 wait_for_nginx
+  curl --header "Periods.Are.Invalid: false" --max-time 1 http://localhost
+  run cat /tmp/nc.log
+  [[ "$output" =~ "Periods.Are.Invalid: false" ]]
+}
+
 @test "It allows underscores in headers" {
   rm /tmp/nc.log || true
   nc -l -p 4000 127.0.0.1 > /tmp/nc.log &


### PR DESCRIPTION
The nginx directive `ingore_invalid_headers` controls whether header fields with invalid names should be ignored.

http://nginx.org/en/docs/http/ngx_http_core_module.html#ignore_invalid_headers

We've historically accepted the default setting of "on" (which drops headers that nginx considers invalid), and will continue to do so by default. However, some customers choose to have `.` (periods) in their headers, and to allow for this we will let the environment variable `IGNORE_INVALID_HEADERS=off` change this behavior.