### PR TITLE
Do not show ELB healthchecks by default.

### DIFF
--- a/templates/etc/nginx/nginx.conf.erb
+++ b/templates/etc/nginx/nginx.conf.erb
@@ -36,6 +36,11 @@ http {
                        '"$request" $status $body_bytes_sent $request_time '
                        '"$http_referer" "$http_user_agent"';
 
+  map $http_user_agent $excluded_ua {
+         ~ELB-HealthChecker  0;
+         default     1;
+  }
+
   # /dev/stdout is a symlink, pointing to /proc/self/fd/1.
   # docker <0.12.0 has issues writing to it (on alpine?) for some reason.
   access_log /proc/self/fd/1;

--- a/templates/etc/nginx/partial/server.conf.erb
+++ b/templates/etc/nginx/partial/server.conf.erb
@@ -1,9 +1,9 @@
 <% if ENV['PROXY_PROTOCOL'] == 'true' %>
   set_real_ip_from 0.0.0.0/0;
   real_ip_header proxy_protocol;
-  access_log /proc/self/fd/1 proxy_log;
+  access_log /proc/self/fd/1 proxy_log <% if ENV['SHOW_ELB_HEALTHCHECKS']%><% else %>if=$excluded_ua<% end %>;
 <% else %>
-  access_log /proc/self/fd/1 http_log;
+  access_log /proc/self/fd/1 http_log <% if ENV['SHOW_ELB_HEALTHCHECKS']%><% else %>if=$excluded_ua<% end %>;
 <% end %>
 
 <% if ENV['HOSTNAME_FILTERING_SERVER_NAME'] %>

--- a/test/nginx.bats
+++ b/test/nginx.bats
@@ -665,6 +665,22 @@ NGINX_VERSION=1.17.3
   [[ "$status" == "500" ]]
 }
 
+@test "${HEALTH_ROUTE} does not log requests from ELB-HealthChecker User Agent" {
+  simulate_upstream
+  UPSTREAM_SERVERS=127.0.0.1:4000 wait_for_nginx
+
+  curl -H 'Host: test.host' -A "ELB-HealthChecker/2.0" "http://localhost/${HEALTH_ROUTE}" > /dev/null 2>&1
+  ! wait_for grep -i 'ELB-HealthChecker' "$NGINX_OUT"
+}
+
+@test "${HEALTH_ROUTE} conditionally can log requests from ELB-HealthChecker User Agent" {
+  simulate_upstream
+  SHOW_ELB_HEALTHCHECKS=true UPSTREAM_SERVERS=127.0.0.1:4000 wait_for_nginx
+
+  curl -H 'Host: test.host' -A "ELB-HealthChecker/2.0" "http://localhost/${HEALTH_ROUTE}" > /dev/null 2>&1
+  wait_for grep -i 'ELB-HealthChecker' "$NGINX_OUT"
+}
+
 @test "${HEALTH_ROUTE} (HTTP): Nginx rewrites the request path to /healthcheck" {
   simulate_upstream
   UPSTREAM_SERVERS=127.0.0.1:4000 wait_for_nginx


### PR DESCRIPTION
After identifying the ELB healthcheck requests by their User Agent, do not show these in the request log, as these are now exposed to customers and are largely without value and definitely noisy.

Errors will still be shown :
```
2019/11/27 20:46:42 [error] 29#0: *227 connect() failed (111: Connection refused) while connecting to upstream, client: 10.58.6.101, server: , request: "GET /.aptible/alb-healthcheck HTTP/1.1", subrequest: "/healthcheck", upstream: "http://10.58.7.217:10456/healthcheck", host: "10.58.7.217:25419"
```

Before : (proxy logs GET /.aptible/alb-healthcheck)
![Screen Shot 2019-11-27 at 15 35 25](https://user-images.githubusercontent.com/1580788/69761349-1e72cb80-1135-11ea-8fc8-a82484a9a03b.png)


After : (just my App logs just GET /healthcheck)
![Screen Shot 2019-11-27 at 15 37 07](https://user-images.githubusercontent.com/1580788/69761352-20d52580-1135-11ea-9e94-be6de78c3d93.png)

In case it's useful, we can re-enable it on a per-App basis : https://github.com/aptible/sweetness/pull/1102