### PR TITLE
Show the amazon request trace ID in the proxy logs.

### DIFF
--- a/templates/etc/nginx/nginx.conf.erb
+++ b/templates/etc/nginx/nginx.conf.erb
@@ -29,12 +29,14 @@ http {
   log_format proxy_log '$proxy_protocol_addr $ssl_protocol/$ssl_cipher '
                        '$host $remote_user [$time_local] '
                        '"$request" $status $body_bytes_sent $request_time '
-                       '"$http_referer" "$http_user_agent"';
+                       '"$http_referer" "$http_user_agent" '
+                       '"$http_x_amzn_trace_id"';
 
   log_format http_log  '$remote_addr:$remote_port $ssl_protocol/$ssl_cipher '
                        '$host $remote_user [$time_local] '
                        '"$request" $status $body_bytes_sent $request_time '
-                       '"$http_referer" "$http_user_agent"';
+                       '"$http_referer" "$http_user_agent" '
+                       '"$http_x_amzn_trace_id"';
 
   # /dev/stdout is a symlink, pointing to /proc/self/fd/1.
   # docker <0.12.0 has issues writing to it (on alpine?) for some reason.

--- a/test/nginx.bats
+++ b/test/nginx.bats
@@ -436,6 +436,15 @@ NGINX_VERSION=1.17.3
   [[ "$status" -eq 1 ]]
 }
 
+@test "It logs the X-Amzn-Trace-Id header for ALB Endpoints." {
+  simulate_upstream
+  UPSTREAM_SERVERS=127.0.0.1:4000 wait_for_nginx
+  curl -sk -H 'X-Amzn-Trace-Id: Root=1-67891233-abcdef012345678912345678' https://localhost
+
+  wait_for grep -i 'get' "$UPSTREAM_OUT"
+  run grep -i 'Root=1-67891233-abcdef01245678912345678' "$UPSTREAM_OUT"
+}
+
 @test "It supports GZIP compression of responses" {
   simulate_upstream
   UPSTREAM_SERVERS=127.0.0.1:4000 wait_for_nginx


### PR DESCRIPTION
If the customer is recording the X-Amzn-Trace-Id in their App logs:

```
2019-11-27T22:32:33.858Z [proxytest-cmd 5f9074287020]: 172.17.0.1 - - [27/Nov/2019 22:32:28] "GET / HTTP/1.1" 200 -
2019-11-27T22:32:33.858Z [proxytest-cmd 5f9074287020]: ERROR:root:X-Forwarded-Proto: http
2019-11-27T22:32:33.858Z [proxytest-cmd 5f9074287020]: X-Forwarded-For: 98.222.216.153, 10.58.0.168
2019-11-27T22:32:33.858Z [proxytest-cmd 5f9074287020]: Host: test.alexkubacki.com
2019-11-27T22:32:33.858Z [proxytest-cmd 5f9074287020]: X-Request-Start: t=1574893948.526
2019-11-27T22:32:33.858Z [proxytest-cmd 5f9074287020]: Connection: upgrade
2019-11-27T22:32:33.858Z [proxytest-cmd 5f9074287020]: X-Forwarded-Port: 80
2019-11-27T22:32:33.858Z [proxytest-cmd 5f9074287020]: X-Amzn-Trace-Id: Root=1-5ddef97c-c6310d584921ad38cc05aaec
2019-11-27T22:32:33.858Z [proxytest-cmd 5f9074287020]: DNT: 1
2019-11-27T22:32:33.858Z [proxytest-cmd 5f9074287020]: Upgrade-Insecure-Requests: 1
2019-11-27T22:32:33.858Z [proxytest-cmd 5f9074287020]: User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36
2019-11-27T22:32:33.858Z [proxytest-cmd 5f9074287020]: Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3
2019-11-27T22:32:33.858Z [proxytest-cmd 5f9074287020]: Accept-Encoding: gzip, deflate
2019-11-27T22:32:33.858Z [proxytest-cmd 5f9074287020]: Accept-Language: en-US,en;q=0.9
```


This will allow them to match it with 100% certainly to the proxy request log:
```
2019-11-27T22:32:34.350Z [proxytest-cmd 48bf6e19eaa8]: 10.58.0.168:53214 -/- test.alexkubacki.com - [27/Nov/2019:22:32:28 +0000] "GET /favicon.ico HTTP/1.1" 200 51 0.002 "http://test.alexkubacki.com/" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36" "Root=1-5ddef97c-f66ded2462f496d4215a559c"
```


This is only an ALB Endpoint feature, but is included in the proxy_log format for the proxy_protocol (eg legacy ELB Endpoints) just so that the log formats are identical (it will show up as `"-"` in the ELB proxy log line).