### PR TITLE
Avoid configuration deprecation warning.

### DIFF
--- a/templates/etc/nginx/partial/ssl.conf.erb
+++ b/templates/etc/nginx/partial/ssl.conf.erb
@@ -1,4 +1,3 @@
-ssl on;
 ssl_certificate <%= ENV.fetch('SSL_CERTIFICATE_FILE') %>;
 ssl_certificate_key <%= ENV.fetch('SSL_KEY_FILE') %>;
 

--- a/templates/etc/nginx/sites-enabled/server.conf.erb
+++ b/templates/etc/nginx/sites-enabled/server.conf.erb
@@ -29,7 +29,7 @@ server {
 }
 
 server {
-  listen 443 <%= 'proxy_protocol' if ENV['PROXY_PROTOCOL'] == 'true' %>;
+  listen 443 ssl <%= 'proxy_protocol' if ENV['PROXY_PROTOCOL'] == 'true' %>;
 
   <% if ENV['FORCE_SSL'] == 'true' %>
     add_header Strict-Transport-Security "max-age=<%= ENV['HSTS_MAX_AGE'] || 31536000 %>" always;
@@ -58,7 +58,7 @@ server {
     # the "real" server. That is fine on Enclave because clients are not
     # connecting directly to Nginx. That said, we should perhaps allow passing
     # 2 certificates here: a default, and one for SNI.
-    listen 443 default_server <%= 'proxy_protocol' if ENV['PROXY_PROTOCOL'] == 'true' %>;
+    listen 443 ssl default_server <%= 'proxy_protocol' if ENV['PROXY_PROTOCOL'] == 'true' %>;
 
     include /etc/nginx/partial/ssl.conf;
     include /etc/nginx/partial/health.conf;

--- a/test/nginx.bats
+++ b/test/nginx.bats
@@ -83,6 +83,12 @@ NGINX_VERSION=1.17.3
   [[ "$output" =~ "$NGINX_VERSION"  ]]
 }
 
+@test "It does not emit any configuration deprecation warnings." {
+  wait_for_nginx
+  ! grep -i "deprecated" "$NGINX_OUT"
+
+}
+
 @test "It does not include the Nginx version" {
   wait_for_nginx
   run curl -v http://localhost


### PR DESCRIPTION
Avoid deprecation warning by replacing "ssl on;" in  with the ssl.conf file with "listen ... ssl" each place it was included.

https://nginx.org/en/docs/http/ngx_http_ssl_module.html?&_ga=2.131880775.9757405.1575306298-417465682.1575306298#ssl