### PR TITLE
Minimize Lua/Resty errors and warnings.

### DIFF
--- a/templates/etc/nginx/nginx.conf.erb
+++ b/templates/etc/nginx/nginx.conf.erb
@@ -53,6 +53,9 @@ http {
 
   server_tokens off;
 
+  # https://gitlab.alpinelinux.org/alpine/aports/issues/10478
+  lua_load_resty_core off;
+
   lua_shared_dict health 128k;
 
   include /etc/nginx/conf.d/*.conf;

--- a/test/nginx.bats
+++ b/test/nginx.bats
@@ -83,6 +83,21 @@ NGINX_VERSION=1.17.3
   [[ "$output" =~ "$NGINX_VERSION"  ]]
 }
 
+@test "It unfortunately shows a LuaJIT warning." {
+  wait_for_nginx
+
+  # We can/should install resty-core if/when it is packaged for alpine.
+  # https://gitlab.alpinelinux.org/alpine/aports/issues/10478
+  grep "detected a LuaJIT version which is not" "$NGINX_OUT"
+}
+
+
+@test "It does not show a lua_load_resty_core error" {
+  wait_for_nginx
+
+  ! grep "lua_load_resty_core failed to load the resty.core module" "$NGINX_OUT"
+}
+
 @test "It does not include the Nginx version" {
   wait_for_nginx
   run curl -v http://localhost


### PR DESCRIPTION
Per the open issue at https://gitlab.alpinelinux.org/alpine/aports/issues/10478, we can eliminate some of these warnings. This will be helpful when sending these logs via Drains.