### PR TITLE
Version bumps.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/aptible/alpine:3.3
+FROM quay.io/aptible/alpine:3.8
 
 # ruby necessary for ERB
 # curl necessary for integration tests

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ If you're on OS X running boot2docker, you can configure your system to trust NG
 
 ## Available Tags
 
-* `latest`: Currently NGiNX 1.17.3
+* `latest`: Currently NGiNX 1.17.6
 
 ## Deployment
 

--- a/install-nginx
+++ b/install-nginx
@@ -5,13 +5,13 @@ set -o pipefail
 
 mkdir /nginx && cd /nginx
 
-NGINX_VERSION='1.17.3'
-NGINX_SHASUM='ce306bc116159f2050f442f35da96ccde93c464d'
+NGINX_VERSION='1.17.6'
+NGINX_SHASUM='58e27d9be6807a85c1e7f076f75b6ec270b7e72e'
 NGINX_RESOURCE="nginx-${NGINX_VERSION}"
 NGINX_ARCHIVE="${NGINX_RESOURCE}.tar.gz"
 
-NGX_DEVEL_KIT_VERSION="0.3.0"
-NGX_DEVEL_KIT_SHASUM="b556d068db23037be30436af559795f45dd93c67"
+NGX_DEVEL_KIT_VERSION="0.3.1"
+NGX_DEVEL_KIT_SHASUM="e15316e13a7b19a3d2502becbb26043a464a135a"
 NGX_DEVEL_KIT_RESOURCE="ngx_devel_kit-${NGX_DEVEL_KIT_VERSION}"
 NGX_DEVEL_KIT_ARCHIVE="${NGX_DEVEL_KIT_RESOURCE}.tar.gz"
 
@@ -48,7 +48,7 @@ cd "$NGINX_RESOURCE"
 apk-install build-base pcre pcre-dev openssl openssl-dev zlib zlib-dev luajit luajit-dev
 
 export LUAJIT_LIB=/usr/lib
-export LUAJIT_INC=/usr/include/luajit-2.0
+export LUAJIT_INC=/usr/include/luajit-2.1
 
 mkdir -p /tmp/nginx
 

--- a/test/nginx.bats
+++ b/test/nginx.bats
@@ -76,11 +76,15 @@ teardown() {
   cp "$TMPDIR"/* /usr/html
 }
 
-NGINX_VERSION=1.17.3
+NGINX_VERSION=1.17.6
 
 @test "It should install nginx $NGINX_VERSION" {
   run /usr/sbin/nginx -v
   [[ "$output" =~ "$NGINX_VERSION"  ]]
+}
+
+@test "It should install a 1.0.2 version of OpenSSL" {
+  openssl version | grep "1.0.2"
 }
 
 @test "It does not include the Nginx version" {


### PR DESCRIPTION
* Nginx - 1.17.3 to 1.17.6 : http://nginx.org/en/CHANGES
* Alpine - upgrade to 3.8.  
* Test that a supported version of OpenSSL is installed. OpenSSL 1.1.1 removes the ability for the client to negotiate a SSLv3 connection, so two tests do not work. I'm not certain if it actually breaks those expectations or just the test, so we'll need to resolve this eventually in order to upgrade to a newer Alpine version with a newer OpenSSL in the future.

```
not ok 26 It allows RC4 for SSLv3
not ok 29 It allows CloudFront-supported ciphers when using SSLv3
```
I'm not certain if it actually breaks those expectations, so we'll need to resolve this eventually.

* ngx devel kit - no real changes: https://github.com/simplresty/ngx_devel_kit/releases