### PR TITLE
Add configurable client_body_timeout and increase default worker_connections

### DIFF
--- a/templates/etc/nginx/nginx.conf.erb
+++ b/templates/etc/nginx/nginx.conf.erb
@@ -3,7 +3,7 @@ worker_processes 4;
 pid /run/nginx.pid;
 
 events {
-  worker_connections <%= ENV['WORKER_CONNECTIONS'] || 768 %>;
+  worker_connections <%= ENV['WORKER_CONNECTIONS'] || 3072 %>;
 }
 
 http {

--- a/templates/etc/nginx/partial/server.conf.erb
+++ b/templates/etc/nginx/partial/server.conf.erb
@@ -13,6 +13,7 @@
 keepalive_timeout <%= ENV['KEEPALIVE_TIMEOUT'] || 5 %>;
 proxy_connect_timeout <%= ENV['PROXY_IDLE_TIMEOUT'] || 60 %>;
 proxy_read_timeout <%= ENV['PROXY_IDLE_TIMEOUT'] || 60 %>;
+client_body_timeout <%= ENV['CLIENT_BODY_TIMEOUT'] || 15 %>;
 
 error_page 502 503 504 /50x.html;
 location /50x.html {


### PR DESCRIPTION
Need to update docker-nginx-tcp, [Sweetness](https://github.com/aptible/sweetness/blob/master/lib/sweetness/plays/app/define_app_tcp_vhost_options.rb) to allow users to set the variable, and the documentation.

- [ ] Nginx TCP
- [ ] Sweetness
- [ ] Docs