### PR TITLE
update 404 page check

### DIFF
--- a/test/nginx.bats
+++ b/test/nginx.bats
@@ -225,7 +225,7 @@ NGINX_VERSION=1.19.1
   UPSTREAM_SERVERS=127.0.0.1:4000 \
     MAINTENANCE_PAGE_URL=https://www.aptible.com/404.html wait_for_nginx
   run curl localhost 2>/dev/null
-  [[ "$output" =~ "@aptiblestatus" ]]
+  [[ "$output" =~ "status.aptible.com" ]]
 }
 
 @test "It should accept a list of UPSTREAM_SERVERS" {


### PR DESCRIPTION
The 404 page used to reference our status twitter, now links to our status page.

This doesn't address the failure at https://travis-ci.com/github/aptible/docker-nginx/builds/205698832#L1615 , so tests may not pass as-is.