### PR TITLE
Add a Access-Control-Allow-Origin header to proxy error responses.

### DIFF
--- a/install-nginx
+++ b/install-nginx
@@ -20,6 +20,11 @@ NGX_LUA_SHASUM="d09f8353ca573ae6a4b33af252433197d6e45b13"
 NGX_LUA_RESOURCE="lua-nginx-module-${NGX_LUA_VERSION}"
 NGX_LUA_ARCHIVE="${NGX_LUA_RESOURCE}.tar.gz"
 
+HEADERS_MORE_VERSION="0.33"
+HEADERS_MORE_SHASUM="7d6af910dae98f0dbc67bf77e82eab8b7da5d0b1"
+HEADERS_MORE_RESOURCE="headers-more-nginx-module-${HEADERS_MORE_VERSION}"
+HEADERS_MORE_ARCHIVE="${HEADERS_MORE_RESOURCE}.tar.gz"
+
 BUILD_DIR="$(mktemp -d)"
 
 cd "$BUILD_DIR"
@@ -35,6 +40,11 @@ tar zxf "$NGX_DEVEL_KIT_ARCHIVE"
 curl -fsSL "https://github.com/openresty/lua-nginx-module/archive/v${NGX_LUA_VERSION}.tar.gz" -o "$NGX_LUA_ARCHIVE"
 echo "${NGX_LUA_SHASUM}  ${NGX_LUA_ARCHIVE}" | sha1sum -c -
 tar zxf "$NGX_LUA_ARCHIVE"
+
+curl -fsSL "https://github.com/openresty/headers-more-nginx-module/archive/v${HEADERS_MORE_VERSION}.tar.gz" -o "$HEADERS_MORE_ARCHIVE"
+sha1sum "${HEADERS_MORE_ARCHIVE}"
+echo "${HEADERS_MORE_SHASUM}  ${HEADERS_MORE_ARCHIVE}" | sha1sum -c -
+tar zfx "$HEADERS_MORE_ARCHIVE"
 
 echo "Downloaded:"
 ls -l
@@ -69,7 +79,8 @@ mkdir -p /tmp/nginx
   --with-http_gzip_static_module \
   --with-http_realip_module \
   --add-module="../${NGX_DEVEL_KIT_RESOURCE}" \
-  --add-module="../${NGX_LUA_RESOURCE}"
+  --add-module="../${NGX_LUA_RESOURCE}" \
+  --add-module="../${HEADERS_MORE_RESOURCE}"
 
 make
 make install

--- a/templates/etc/nginx/partial/server.conf.erb
+++ b/templates/etc/nginx/partial/server.conf.erb
@@ -17,6 +17,7 @@ client_body_timeout <%= ENV['CLIENT_BODY_TIMEOUT'] || 15 %>;
 
 error_page 502 503 504 /50x.html;
 location /50x.html {
+  more_set_headers 'Access-Control-Allow-Origin: *';
 }
 
 <% if ENV['ACME_SERVER'] %>

--- a/test/nginx.bats
+++ b/test/nginx.bats
@@ -1237,3 +1237,16 @@ NGINX_VERSION=1.19.1
 
   grep 'HTTP/1.1 200' <<< "$output"
 }
+
+@test "It should not set Access-Control-Allow-Origin for proxied requests" {
+  FORCE_SSL=true wait_for_nginx
+  run curl -Ik https://localhost 2>/dev/null
+  ! [[ "$output" =~ "Access-Control-Allow-Origin" ]]
+}
+
+@test "It should set Access-Control-Allow-Origin if we return an error on behalf of a failed upstream" {
+  UPSTREAM_DELAY=5 simulate_upstream
+  PROXY_IDLE_TIMEOUT=1 UPSTREAM_SERVERS=127.0.0.1:4000 wait_for_nginx
+  run curl -Ik https://localhost 2>/dev/null
+  [[ "$output" =~ "Access-Control-Allow-Origin" ]]
+}


### PR DESCRIPTION
By adding the `Access-Control-Allow-Origin: *` header on 5xx responses, a single page app will no longer refuse to load the error response we send if their API is unresponsive.