### PR TITLE
Don't consider upstream dead with just 1 failure.

### DIFF
--- a/templates/etc/nginx/sites-enabled/server.conf.erb
+++ b/templates/etc/nginx/sites-enabled/server.conf.erb
@@ -1,7 +1,7 @@
 <% if ENV['UPSTREAM_SERVERS'] %>
 upstream containers {
   <% (ENV['UPSTREAM_SERVERS']).split(',').each do |server| %>
-    server <%= server %>;
+    server <%= server %> max_fails=10;
   <% end %>
 }
 <% end %>


### PR DESCRIPTION
Occasionally the nginx proxy may have more than 1 upstream (App container), and a single failure to connect will cause an upstream to be considered unhealthy and no requests will be routed to it for the next 10 seconds. However, if all upstream emit an error at the same time, all requests fail with a `no live upstream` error.

By upping `max_fails` from the default of 1 to 10, an upstream would have to return 10 connection errors (within 10 seconds, the default `fail_timeout `) in order to be considered unhealthy. This will allow for transient issues to be less impactful, though we obviously can't force an upstream App to respond.