### PR TITLE
set max_fails

### DIFF
--- a/templates/etc/nginx/sites-enabled/server.conf.erb
+++ b/templates/etc/nginx/sites-enabled/server.conf.erb
@@ -1,7 +1,7 @@
 <% if ENV['UPSTREAM_SERVERS'] %>
 upstream containers {
   <% (ENV['UPSTREAM_SERVERS']).split(',').each do |server| %>
-    server <%= server %>;
+    server <%= server %> max_fails=10;
   <% end %>
 }
 <% end %>


### PR DESCRIPTION
adjust `max_fails=10` up from default of 1
see: https://nginx.org/en/docs/http/ngx_http_upstream_module.html

re-implementation of https://github.com/aptible/docker-nginx/pull/131